### PR TITLE
Include a link in the alert for anonymous users. Fixes #253

### DIFF
--- a/pybossa/view/applications.py
+++ b/pybossa/view/applications.py
@@ -306,7 +306,9 @@ def import_task(short_name):
 def task_presenter(short_name, task_id):
     if (current_user.is_anonymous()):
         flash("Ooops! You are an anonymous user and will not get any credit "
-              " for your contributions. Sign in now!", "warning")
+              " for your contributions. <a href=\"" + url_for('account.signin',
+              next=url_for('app.task_presenter',short_name=short_name,task_id=task_id)) \
+              + "\">Sign in now!</a>", "warning")
     app = App.query.filter_by(short_name=short_name)\
             .first_or_404()
     task = db.session.query(model.Task).get(task_id)
@@ -343,18 +345,31 @@ def task_presenter(short_name, task_id):
 def presenter(short_name):
     app = App.query.filter_by(short_name=short_name)\
             .first_or_404()
-    if (current_user.is_anonymous()):
-        flash("Ooops! You are an anonymous user and will not get any credit "
-              "for your contributions. Sign in now!", "warning")
     if app.info.get("tutorial"):
         if request.cookies.get(app.short_name + "tutorial") is None:
+            if (current_user.is_anonymous()):
+                flash("Ooops! You are an anonymous user and will not get any credit "
+                        " for your contributions. <a href=\"" + url_for('account.signin',
+                            next=url_for('app.tutorial',short_name=short_name)) \
+                      + "\">Sign in now!</a>", "warning")
             resp = make_response(render_template('/applications/tutorial.html',
                 app=app))
             resp.set_cookie(app.short_name + 'tutorial', 'seen')
             return resp
         else:
+            if (current_user.is_anonymous()):
+                flash("Ooops! You are an anonymous user and will not get any credit "
+                        " for your contributions. <a href=\"" + url_for('account.signin',
+                            next=url_for('app.presenter',short_name=short_name)) \
+                      + "\">Sign in now!</a>", "warning")
             return render_template('/applications/presenter.html', app=app)
     else:
+        if (current_user.is_anonymous()):
+           flash("Ooops! You are an anonymous user and will not get any credit "
+                   " for your contributions. <a href=\"" + url_for('account.signin',
+                       next=url_for('app.presenter',short_name=short_name)) \
+                 + "\">Sign in now!</a>", "warning")
+
         return render_template('/applications/presenter.html', app=app)
 
 

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -918,6 +918,8 @@ class TestWeb:
         res = self.app.get('app/%s/task/%s' % (app.short_name, task.id),
                 follow_redirects=True)
         assert 'TaskPresenter' in res.data, res.data
+        assert "?next=%2Fapp%2F" + app.short_name +"%2Ftask%2F" + str(task.id),\
+                res.data
 
     def test_22_get_specific_completed_task_anonymous(self):
         """Test WEB get specific completed task_id
@@ -1051,11 +1053,13 @@ class TestWeb:
         app1 = db.session.query(model.App).get(1)
         app1.info = dict(tutorial="some help")
         db.session.commit()
-        self.register()
+        #self.register()
         # First time accessing the app should redirect me to the tutorial
         res = self.app.get('/app/test-app/newtask', follow_redirects=True)
         assert "some help" in res.data,\
                 "There should be some tutorial for the application"
+        assert "?next=%2Fapp%2Ftest-app%2Ftutorial" in res.data,\
+                "There should be a link to Sign in and redirect to tutorial"
         # Second time should give me a task, and not the tutorial
         res = self.app.get('/app/test-app/newtask', follow_redirects=True)
         assert "some help" not in res.data
@@ -1395,5 +1399,3 @@ class TestWeb:
                 }, follow_redirects=True)
             assert 'Click here to recover your account' in outbox[0].body
             assert 'your Twitter account to ' in outbox[1].body
-
-


### PR DESCRIPTION
This commit fixes the issue #253 by including a link for sign in, and
redirecting the anonymous user to the correct page.
