### PR TITLE
Show the right n_answers in the tasks page. Closes #294

### DIFF
--- a/pybossa/api.py
+++ b/pybossa/api.py
@@ -80,6 +80,7 @@ class APIBase(MethodView):
                 except (ValueError, TypeError):
                     offset = 0
 
+                query = query.order_by(self.__class__.id)
                 query = query.limit(limit)
                 query = query.offset(offset)
                 items = [x.dictize() for x in query.all()]

--- a/pybossa/templates/applications/tasks.html
+++ b/pybossa/templates/applications/tasks.html
@@ -63,7 +63,11 @@
                         {% else %}
                           Task <span class="label label-info">#{{ t.id }}</span>
                         {% endif %}
-                          {{ t.task_runs | count }} of {{ t.info['n_answers'] | default('30')}}
+                        {% if t.info['n_answers'] %}
+                          {{ t.task_runs | count }} of {{ t.info['n_answers'] }}
+                        {% else %}
+                          {{ t.task_runs | count }} of {{ t.n_answers }}
+                        {% endif %}
                     </div>
                         {% if task_pct >= 100 %}
                         <div class="progress progress-success progress-striped span5"> 


### PR DESCRIPTION
This commit also fixes a problem with the api GET action, as the items
were not ordered. This caused strange behaviors when using the API with
the offset and limit args.
