### PR TITLE
Top users and top and featured apps now cached. Closes #300

### DIFF
--- a/pybossa/templates/home/index.html
+++ b/pybossa/templates/home/index.html
@@ -76,11 +76,11 @@
             <a data-content="
                 <strong>Joined:</strong> {{item.user.created[0:10]}} 
                 <br/>
-                <strong>Submitted Tasks:</strong> {{item.user.task_runs|length}}
+                <strong>Submitted Tasks:</strong> {{item.task_runs}}
                 " rel="popover" data-original-title="<strong>{{item.user.fullname}}</strong>">
                 <img src="{{item.user.email_addr|gravatar(size=90)}}">
            </a>
-           <span class="label label-success">{{item.user.task_runs|length}}</span> <small>Tasks</small>
+           <span class="label label-success">{{item.task_runs}}</span> <small>Tasks</small>
           </li>
           {% endfor %}
         </ul>


### PR DESCRIPTION
This commit moves the front page actions of getting the top users and apps,
as well as the featured ones to the util.py module in order to provide caching
mechanisms at function level. Thanks to this caching improvements, loading the
front page only causes 1 SQL query, while without it gets 21. The improvement is
really big.
