### PR TITLE
Fix owner_id bug. Closes #348

### DIFF
--- a/pybossa/view/applications.py
+++ b/pybossa/view/applications.py
@@ -170,7 +170,13 @@ def task_presenter_editor(short_name):
                 if app.info.get('task_presenter'):
                     form.editor.data = app.info['task_presenter']
                 else:
-                    form.editor.data = "<h1>Write your code here!<h1>"
+                    script = "<script>\n"
+                    script += "// Your JavaScript\n"
+                    script += "pybossa.taskLoaded(function(task, deferred){\n\t//  Load your task\n});\n"
+                    script += "pybossa.presentTask(function(task, deferred){\n\t// Present task\n});\n"
+                    script += "pybossa.run('%s');\n" % app.short_name
+                    script += "</script>"
+                    form.editor.data = "<h1>Write here the HTML for your app<h1>\n" + script
                 flash('Your code will be <em>automagically</em> rendered in \
                       the <strong>view section</strong>', 'info')
                 return render_template('applications/task_presenter_editor.html',
@@ -254,7 +260,7 @@ def update(short_name):
                                             long_description=form.long_description.data,
                                             hidden=hidden,
                                             info=info,
-                                            owner_id=current_user.id,)
+                                            owner_id=app.owner_id,)
                 app = App.query.filter_by(short_name=short_name).first_or_404()
                 db.session.merge(new_application)
                 db.session.commit()

--- a/test/test_admin.py
+++ b/test/test_admin.py
@@ -449,6 +449,12 @@ class TestAdmin:
         res = self.app.get('/app/rootsampleapp', follow_redirects=True)
         assert "Root" in res.data, "The app should be updated by admin users"
 
+        app = db.session.query(model.App)\
+                .filter_by(short_name="rootsampleapp").first()
+        juan = db.session.query(model.User).filter_by(name="juan").first()
+        assert app.owner_id == juan.id, "Owner_id should be: %s" % juan.id
+        assert app.owner_id != 1, "The owner should be not updated"
+
     def test_17_admin_delete_app(self):
         """Test ADMIN can delete an app that belongs to another user"""
         self.register()


### PR DESCRIPTION
This commit keeps the owner_id if the application if a root user
updates an app
