### PR TITLE
Fix Flask-Mail hack to make pass unit test.

### DIFF
--- a/settings_test.py
+++ b/settings_test.py
@@ -14,6 +14,6 @@ MAIL_USERNAME = None
 MAIL_PASSWORD = None
 MAIL_PORT = 25
 MAIL_FAIL_SILENTLY = False
-DEFAULT_MAIL_SENDER = 'PyBossa Support <info@pybossa.com>'
+MAIL_DEFAULT_SENDER = 'PyBossa Support <info@pybossa.com>'
 ANNOUNCEMENT = {'admin': 'Root Message', 'user': 'User Message', 'owner': 'Owner Message'}
 LOCALES = ['en', 'es']

--- a/test/base.py
+++ b/test/base.py
@@ -10,12 +10,20 @@ web.app.config['TESTING'] = True
 web.app.config['CSRF_ENABLED'] = False
 web.app.config['SQLALCHEMY_DATABASE_URI'] = web.app.config['SQLALCHEMY_DATABASE_TEST_URI']
 web.app.config['CSRF_ENABLED'] = False
+web.app.config['MAIL_SERVER'] = 'localhost'
+web.app.config['MAIL_USERNAME'] = None
+web.app.config['MAIL_PASSWORD'] = None
+web.app.config['MAIL_PORT'] = 25
+web.app.config['MAIL_FAIL_SILENTLY'] = False
+web.app.config['MAIL_DEFAULT_SENDER'] = 'PyBossa Support <info@pybossa.com>'
+
 web.cache.config['CACHE_TYPE'] = 'null'
 web.cache.config['TESTING'] = True
 web.app.config['ANNOUNCEMENT'] = {'admin': 'Root Message',
                                   'user': 'User Message',
                                   'owner': 'Owner Message'}
 cache.init_app(web.app)
+mail.init_app(web.app)
 #engine = model.create_engine(web.app.config['SQLALCHEMY_DATABASE_URI'])
 #model.set_engine(engine)
 

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -1178,9 +1178,6 @@ class TestWeb(web.Helper):
         jane.twitter_user_id = 10
         db.session.add(jane)
         db.session.commit()
-        # TODO: This is a hack to get tests working. Documented method to
-        # supress mail sending doesn't seem to work
-        mail.suppress = True
         with mail.record_messages() as outbox:
             self.app.post('/account/forgot-password',
                           data={'email_addr': self.user.email_addr},


### PR DESCRIPTION
This commit fixes the TODO item in the test_web.py file that had
a typo in the config variable MAIL_DEFAULT_SENDER (it was written DEFAULT_MAIL_SENDER).
