### PR TITLE
Bugfix for loading all tasks into memmory for each userprogress request (each task run)

### DIFF
--- a/pybossa/api.py
+++ b/pybossa/api.py
@@ -326,15 +326,15 @@ def user_progress(app_id=None, short_name=None):
             if current_user.is_anonymous():
                 tr = db.session.query(model.TaskRun)\
                        .filter(model.TaskRun.app_id == app.id)\
-                       .filter(model.TaskRun.user_ip == request.remote_addr)\
-                       .all()
+                       .filter(model.TaskRun.user_ip == request.remote_addr)
             else:
                 tr = db.session.query(model.TaskRun)\
                        .filter(model.TaskRun.app_id == app.id)\
-                       .filter(model.TaskRun.user_id == current_user.id)\
-                       .all()
+                       .filter(model.TaskRun.user_id == current_user.id)
+            tasks = db.session.query(model.Task)\
+                .filter(model.Task.app_id == app.id)
             # Return
-            tmp = dict(done=len(tr), total=len(app.tasks))
+            tmp = dict(done=tr.count(), total=tasks.count())
             return Response(json.dumps(tmp), mimetype="application/json")
         else:
             return abort(404)


### PR DESCRIPTION
Please test your code with a dummy dataset with > 10000 tasks, and possibly the same for apps and users... I haven't done an exhaustive search of the app for this kind of problems, just fixed the one that took down our server...
