### PR TITLE
Only allow one answer per user and task

### DIFF
--- a/pybossa/api.py
+++ b/pybossa/api.py
@@ -254,6 +254,10 @@ class TaskRunAPI(APIBase):
     def _update_object(self, obj):
         if not current_user.is_anonymous():
             obj.user = current_user
+            if db.session.query(model.TaskRun).filter(model.TaskRun.app_id==obj.app_id,
+                                                      model.TaskRun.task_id==obj.task_id,
+                                                      model.TaskRun.user==obj.user).count() > 0:
+                raise Exception("You have already submitted an answer for this task...")
         else:
             obj.user_ip = request.remote_addr
 


### PR DESCRIPTION
Sometimes apps do starnge things, esp. if the network is a bit slow / unreliable, and we might get duplicate responses from the same user for the same task.

I have fixed that in our apps, but also added a server side guard against this problem. This is that server side guard.
