### PR TITLE
Issues 736 737 export error

### DIFF
--- a/pybossa/core.py
+++ b/pybossa/core.py
@@ -53,8 +53,7 @@ def create_app(theme='default'):
     setup_gravatar(app)
     #gravatar = Gravatar(app, size=100, rating='g', default='mm',
                         #force_default=False, force_lower=False)
-    db.app = app
-    db.init_app(app)
+    setup_db(app)
     mail.init_app(app)
     sentinel.init_app(app)
     signer.init_app(app)
@@ -86,6 +85,11 @@ def configure_app(app):
 
 def setup_markdown(app):
     misaka.init_app(app)
+
+
+def setup_db(app):
+    db.app = app
+    db.init_app(app)
 
 
 def setup_gravatar(app):


### PR DESCRIPTION
Closes #736 
Closes #737 

This error was caused by the SQLAlchemy db instance not having a reference to the current app. Notice that it was raised only in functions that "yield" instead of "return", like in https://github.com/PyBossa/pybossa/blob/95f60cf27f473ab9a7607334b7929d13ebee0c73/pybossa/view/admin.py#L188-L192.

The funny thing is that it did not arise in the tests, probably because of the test_context() used in them.

More information about it:
http://librelist.com/browser/flask/2010/8/30/sqlalchemy-init-app-problem/#b1c3beb68573efef4d6e571ebc68fa0b
http://stackoverflow.com/questions/19437883/when-scattering-flask-models-runtimeerror-application-not-registered-on-db-w
And specially here:
http://piotr.banaszkiewicz.org/blog/2012/06/29/flask-sqlalchemy-init_app/ where it is said that the approach taken in this PR might mess up db internals, while I don't know how true this assertion is, as the author seems not to know it either.

So, to avoid this, a different workaround to fix this issue can be taken, which is basically not using the "yield" in the functions and use "return" instead, but I think this same issue will arise again, sooner or later, so I prefer as proposed here.
