### PR TITLE
Issue error tasks browse

### DIFF
--- a/pybossa/model/task.py
+++ b/pybossa/model/task.py
@@ -60,11 +60,10 @@ class Task(db.Model, DomainObject):
         """Returns the percentage of Tasks that are completed"""
         # DEPRECATED: self.info.n_answers will be removed
         # DEPRECATED: use self.n_answers instead
-        n_answers = None
-        if self.n_answers:
-            n_answers = self.n_answers
-        elif (self.info.get('n_answers')):
+        if (self.info.get('n_answers')):
             n_answers = int(self.info['n_answers'])
+        else:
+            n_answers = self.n_answers
         if n_answers != 0 and n_answers != None:
             return float(len(self.task_runs)) / n_answers
         else:  # pragma: no cover


### PR DESCRIPTION
This PR fixes an error produced when a project tasks keep their n_answers value as a field inside their "info" field. When consulting the value, it modified the n_answers field, which should not do, as it is a read-only query.
