### PR TITLE
Use unicode instead of str to render category names

### DIFF
--- a/pybossa/view/home.py
+++ b/pybossa/view/home.py
@@ -47,7 +47,7 @@ def home():
     d['categories_apps'] = {}
     for c in categories:
         tmp_apps = cached_apps.get(c['short_name'], page, per_page)
-        d['categories_apps'][unicode(c['short_name'])] = tmp_apps
+        d['categories_apps'][c['short_name']] = tmp_apps
 
     # Add featured
     tmp_apps = cached_apps.get_featured('featured', page, per_page)


### PR DESCRIPTION
Fixes #764
