### PR TITLE
Faster travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
 - export PATH=${PATH}:`pwd`/$SWIG/vendor/bin
 - redis-server --version
 - redis-server contrib/redis/sentinel.conf --sentinel
-- pip install coveralls --use-mirrors
+- pip install coveralls
 install:
 - pip install -r requirements.txt
 before_script:


### PR DESCRIPTION
Uses docker based Travis CI Build process which is new and it feels also faster (starts in less than 10 seconds). Also more CPU power on Travis CI side for this setup.

More info:
http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
http://docs.travis-ci.com/user/workers/container-based-infrastructure/
