### PR TITLE
Update cors settings

### DIFF
--- a/pybossa/default_settings.py
+++ b/pybossa/default_settings.py
@@ -127,11 +127,11 @@ PRO_FEATURES = {
     'better_stats':          True
 }
 
-CORS_RESOURCES = {r"/api/*": {"origins": "*",
-                              "allow_headers": ['Content-Type',
-                                                'Authorization'],
-                              "max_age": 21600
-                              }}
+CORS_RESOURCES = {r"/*": {"origins": "*",
+                          "allow_headers": ['Content-Type',
+                                            'Authorization'],
+                          "max_age": 21600
+                          }}
 
 FAILED_JOBS_RETRIES = 3
 FAILED_JOBS_MAILS = 7

--- a/settings_local.py.tmpl
+++ b/settings_local.py.tmpl
@@ -197,7 +197,7 @@ LIBSASS_STYLE = 'compressed'
 # CORS_RESOURCES = {r"/api/*": {"origins": "*",
 #                               "allow_headers": ['Content-Type',
 #                                                 'Authorization'],
-#                               "methods": "*"
+#                               "max_age": 21600
 #                               }}
 
 # Email notifications for background jobs.


### PR DESCRIPTION
Would it make sense to open up the CORS settings for all routes by default, now that most of those routes also speak JSON?

Alternatively, a note to say that the new endpoints won't work until CORS_RESOURCE is updated!
