### PR TITLE
Issue project stats in a new table

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: required
 dist: trusty
+group: edge
 language: python
 python:
 - '2.7'

--- a/alembic/versions/d1add5e3e65e_projects_stats.py
+++ b/alembic/versions/d1add5e3e65e_projects_stats.py
@@ -27,6 +27,8 @@ def upgrade():
         sa.Column('n_tasks', sa.Integer, default=0),
         sa.Column('n_task_runs', sa.Integer, default=0),
         sa.Column('n_results', sa.Integer, default=0),
+        sa.Column('n_volunteers', sa.Integer, default=0),
+        sa.Column('n_completed_tasks', sa.Integer, default=0),
         sa.Column('overall_progress', sa.Integer, default=0),
         sa.Column('last_activity', sa.Text, default=make_timestamp),
         sa.Column('info', JSON, nullable=False)

--- a/alembic/versions/d1add5e3e65e_projects_stats.py
+++ b/alembic/versions/d1add5e3e65e_projects_stats.py
@@ -31,6 +31,7 @@ def upgrade():
         sa.Column('n_completed_tasks', sa.Integer, default=0),
         sa.Column('overall_progress', sa.Integer, default=0),
         sa.Column('average_time', sa.Float, default=0),
+        sa.Column('n_blogposts', sa.Integer, default=0),
         sa.Column('last_activity', sa.Text, default=make_timestamp),
         sa.Column('info', JSON, nullable=False)
     )

--- a/alembic/versions/d1add5e3e65e_projects_stats.py
+++ b/alembic/versions/d1add5e3e65e_projects_stats.py
@@ -30,6 +30,7 @@ def upgrade():
         sa.Column('n_volunteers', sa.Integer, default=0),
         sa.Column('n_completed_tasks', sa.Integer, default=0),
         sa.Column('overall_progress', sa.Integer, default=0),
+        sa.Column('average_time', sa.Float, default=0),
         sa.Column('last_activity', sa.Text, default=make_timestamp),
         sa.Column('info', JSON, nullable=False)
     )

--- a/alembic/versions/d1add5e3e65e_projects_stats.py
+++ b/alembic/versions/d1add5e3e65e_projects_stats.py
@@ -1,0 +1,37 @@
+"""projects_stats
+
+Revision ID: d1add5e3e65e
+Revises: ca9164362ca2
+Create Date: 2017-06-16 14:03:24.978654
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'd1add5e3e65e'
+down_revision = 'ca9164362ca2'
+
+from sqlalchemy.dialects.postgresql import JSON
+from alembic import op
+import sqlalchemy as sa
+
+def make_timestamp():
+    now = datetime.datetime.utcnow()
+    return now.isoformat()
+
+
+def upgrade():
+    op.create_table(
+        'project_stats',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('project_id', sa.Integer, sa.ForeignKey('project.id')),
+        sa.Column('n_tasks', sa.Integer, default=0),
+        sa.Column('n_task_runs', sa.Integer, default=0),
+        sa.Column('n_results', sa.Integer, default=0),
+        sa.Column('overall_progress', sa.Integer, default=0),
+        sa.Column('last_activity', sa.Text, default=make_timestamp),
+        sa.Column('info', JSON, nullable=False)
+    )
+
+
+def downgrade():
+    op.drop_table('project_stats')

--- a/alembic/versions/d1add5e3e65e_projects_stats.py
+++ b/alembic/versions/d1add5e3e65e_projects_stats.py
@@ -23,7 +23,8 @@ def upgrade():
     op.create_table(
         'project_stats',
         sa.Column('id', sa.Integer, primary_key=True),
-        sa.Column('project_id', sa.Integer, sa.ForeignKey('project.id')),
+        sa.Column('project_id', sa.Integer, sa.ForeignKey('project.id',
+                                                          ondelete='CASCADE')),
         sa.Column('n_tasks', sa.Integer, default=0),
         sa.Column('n_task_runs', sa.Integer, default=0),
         sa.Column('n_results', sa.Integer, default=0),

--- a/pybossa/cache/helpers.py
+++ b/pybossa/cache/helpers.py
@@ -89,18 +89,11 @@ def add_custom_contrib_button_to(project, user_id_or_ip, ps=None):
     project['contrib_button'] = check_contributing_state(project,
                                                          ps=ps,
                                                          **user_id_or_ip)
-    query = text('''
-                 SELECT COUNT(id) as ct from blogpost
-                 WHERE project_id=:project_id;
-                 ''')
     if ps is None:
         ps = session.query(ProjectStats)\
                     .filter_by(project_id=project['id']).first()
 
-    results = session.execute(query, dict(project_id=project['id']))
-    for row in results:
-        project['n_blogposts'] = row.ct
-
+    project['n_blogposts'] = ps.n_blogposts
     project['n_results'] = ps.n_results
 
     return project

--- a/pybossa/cache/helpers.py
+++ b/pybossa/cache/helpers.py
@@ -59,7 +59,7 @@ def n_available_tasks(project_id, user_id=None, user_ip=None):
     return n_tasks
 
 
-def check_contributing_state(project, user_id=None, user_ip=None):
+def check_contributing_state(project, user_id=None, user_ip=None, ps=None):
     """Return the state of a given project for a given user.
 
     Depending on whether the project is completed or not and the user can
@@ -68,8 +68,9 @@ def check_contributing_state(project, user_id=None, user_ip=None):
     project_id = project['id'] if type(project) == dict else project.id
     published = project['published'] if type(project) == dict else project.published
     states = ('completed', 'draft', 'publish', 'can_contribute', 'cannot_contribute')
-    ps = session.query(ProjectStats)\
-                .filter_by(project_id=project_id).first()
+    if ps is None:
+        ps = session.query(ProjectStats)\
+                    .filter_by(project_id=project_id).first()
     if ps.overall_progress >= 100:
         return states[0]
     if not published:
@@ -81,18 +82,20 @@ def check_contributing_state(project, user_id=None, user_ip=None):
     return states[4]
 
 
-def add_custom_contrib_button_to(project, user_id_or_ip):
+def add_custom_contrib_button_to(project, user_id_or_ip, ps=None):
     """Add a customized contrib button for a project."""
     if type(project) != dict:
         project = project.dictize()
     project['contrib_button'] = check_contributing_state(project,
+                                                         ps=ps,
                                                          **user_id_or_ip)
     query = text('''
                  SELECT COUNT(id) as ct from blogpost
                  WHERE project_id=:project_id;
                  ''')
-    ps = session.query(ProjectStats)\
-                .filter_by(project_id=project['id']).first()
+    if ps is None:
+        ps = session.query(ProjectStats)\
+                    .filter_by(project_id=project['id']).first()
 
     results = session.execute(query, dict(project_id=project['id']))
     for row in results:

--- a/pybossa/cache/project_stats.py
+++ b/pybossa/cache/project_stats.py
@@ -579,5 +579,5 @@ def update_stats(project_id, geo=False, period='2 week'):
 def get_stats(project_id, geo=False, period='2 week'):
     """Get project's stats."""
     ps = session.query(ProjectStats).filter_by(project_id=project_id).first()
-    update_stats(project_id, geo, period)
+    #update_stats(project_id, geo, period)
     return ps.info['dates_stats'], ps.info['hours_stats'], ps.info['users_stats']

--- a/pybossa/cache/project_stats.py
+++ b/pybossa/cache/project_stats.py
@@ -567,17 +567,22 @@ def update_stats(project_id, geo=False, period='2 week'):
                 hours_stats=hours_stats,
                 users_stats=users_stats)
     ps = session.query(ProjectStats).filter_by(project_id=project_id).first()
+
     n_tasks = cached_projects.n_tasks(project_id)
     n_task_runs = cached_projects.n_task_runs(project_id)
     n_results = cached_projects.n_results(project_id)
     overall_progress = cached_projects.overall_progress(project_id)
     last_activity = cached_projects.last_activity(project_id)
+    n_volunteers = cached_projects.n_volunteers(project_id)
+    n_completed_tasks = cached_projects.n_completed_tasks(project_id)
 
     if ps is None:
         ps = ProjectStats(project_id=project_id, info=data,
                           n_tasks=n_tasks,
                           n_task_runs=n_task_runs,
                           n_results=n_results,
+                          n_volunteers=n_volunteers,
+                          n_completed_tasks=n_completed_tasks,
                           overall_progress=overall_progress,
                           last_activity=last_activity)
         db.session.add(ps)
@@ -587,6 +592,9 @@ def update_stats(project_id, geo=False, period='2 week'):
         ps.n_task_runs = n_task_runs
         ps.overall_progress = overall_progress
         ps.last_activity = last_activity
+        ps.n_results = n_results
+        ps.n_completed_tasks = n_completed_tasks
+        ps.n_volunteers = n_volunteers
     db.session.commit()
     return dates_stats, hours_stats, users_stats
 

--- a/pybossa/cache/project_stats.py
+++ b/pybossa/cache/project_stats.py
@@ -576,6 +576,7 @@ def update_stats(project_id, geo=False, period='2 week'):
     n_volunteers = cached_projects.n_volunteers(project_id)
     n_completed_tasks = cached_projects.n_completed_tasks(project_id)
     average_time = cached_projects.average_contribution_time(project_id)
+    n_blogposts = cached_projects.n_blogposts(project_id)
 
     if ps is None:
         ps = ProjectStats(project_id=project_id, info=data,
@@ -586,6 +587,7 @@ def update_stats(project_id, geo=False, period='2 week'):
                           n_completed_tasks=n_completed_tasks,
                           average_time=average_time,
                           overall_progress=overall_progress,
+                          n_blogposts=n_blogposts,
                           last_activity=last_activity)
         db.session.add(ps)
     else:
@@ -598,6 +600,7 @@ def update_stats(project_id, geo=False, period='2 week'):
         ps.n_completed_tasks = n_completed_tasks
         ps.n_volunteers = n_volunteers
         ps.average_time = average_time
+        ps.n_blogposts = n_blogposts
     db.session.commit()
     return dates_stats, hours_stats, users_stats
 

--- a/pybossa/cache/project_stats.py
+++ b/pybossa/cache/project_stats.py
@@ -575,6 +575,7 @@ def update_stats(project_id, geo=False, period='2 week'):
     last_activity = cached_projects.last_activity(project_id)
     n_volunteers = cached_projects.n_volunteers(project_id)
     n_completed_tasks = cached_projects.n_completed_tasks(project_id)
+    average_time = cached_projects.average_contribution_time(project_id)
 
     if ps is None:
         ps = ProjectStats(project_id=project_id, info=data,
@@ -583,6 +584,7 @@ def update_stats(project_id, geo=False, period='2 week'):
                           n_results=n_results,
                           n_volunteers=n_volunteers,
                           n_completed_tasks=n_completed_tasks,
+                          average_time=average_time,
                           overall_progress=overall_progress,
                           last_activity=last_activity)
         db.session.add(ps)
@@ -595,6 +597,7 @@ def update_stats(project_id, geo=False, period='2 week'):
         ps.n_results = n_results
         ps.n_completed_tasks = n_completed_tasks
         ps.n_volunteers = n_volunteers
+        ps.average_time = average_time
     db.session.commit()
     return dates_stats, hours_stats, users_stats
 

--- a/pybossa/cache/project_stats.py
+++ b/pybossa/cache/project_stats.py
@@ -19,7 +19,7 @@
 from flask import current_app
 from sqlalchemy.sql import text
 from pybossa.core import db
-from pybossa.cache import memoize, ONE_DAY
+from pybossa.cache import memoize, ONE_DAY, FIVE_MINUTES
 import pybossa.cache.projects as cached_projects
 from pybossa.model.project_stats import ProjectStats
 from flask.ext.babel import gettext
@@ -541,7 +541,6 @@ def stats_format_users(project_id, users, anon_users, auth_users, geo=False):
                 n_anon=users['n_anon'], n_auth=users['n_auth'])
 
 
-#@memoize(timeout=ONE_DAY)
 def update_stats(project_id, geo=False, period='2 week'):
     """Update the stats of a given project."""
     hours, hours_anon, hours_auth, max_hours, \
@@ -605,8 +604,8 @@ def update_stats(project_id, geo=False, period='2 week'):
     return dates_stats, hours_stats, users_stats
 
 
+@memoize(timeout=FIVE_MINUTES)
 def get_stats(project_id, geo=False, period='2 week'):
     """Get project's stats."""
     ps = session.query(ProjectStats).filter_by(project_id=project_id).first()
-    #update_stats(project_id, geo, period)
     return ps.info['dates_stats'], ps.info['hours_stats'], ps.info['users_stats']

--- a/pybossa/cache/projects.py
+++ b/pybossa/cache/projects.py
@@ -219,7 +219,10 @@ def average_contribution_time(project_id):
     results = session.execute(sql, dict(project_id=project_id)).fetchall()
     for row in results:
         average_time = row.average_time
-    return average_time.total_seconds() or 0
+    if average_time:
+        return average_time.total_seconds()
+    else:
+        return 0
 
 
 def n_blogposts(project_id):

--- a/pybossa/cache/projects.py
+++ b/pybossa/cache/projects.py
@@ -222,6 +222,19 @@ def average_contribution_time(project_id):
     return average_time.total_seconds() or 0
 
 
+def n_blogposts(project_id):
+    """Return number of blogposts of a project."""
+    sql = text('''
+               SELECT COUNT(id) as ct from blogpost
+               WHERE project_id=:project_id;
+               ''')
+    results = session.execute(sql, dict(project_id=project_id))
+    n_blogposts = 0
+    for row in results:
+        n_blogposts = row.ct
+    return n_blogposts
+
+
 # This function does not change too much, so cache it for a longer time
 @cache(timeout=timeouts.get('STATS_FRONTPAGE_TIMEOUT'),
        key_prefix="number_featured_projects")

--- a/pybossa/cache/projects.py
+++ b/pybossa/cache/projects.py
@@ -219,7 +219,7 @@ def average_contribution_time(project_id):
     results = session.execute(sql, dict(project_id=project_id)).fetchall()
     for row in results:
         average_time = row.average_time
-    return average_time or 0
+    return average_time.total_seconds() or 0
 
 
 # This function does not change too much, so cache it for a longer time

--- a/pybossa/exporter/csv_export.py
+++ b/pybossa/exporter/csv_export.py
@@ -69,3 +69,4 @@ class CsvExporter(Exporter):
         print "%d (csv)" % project.id
         self._make_zip(project, "task")
         self._make_zip(project, "task_run")
+        self._make_zip(project, "result")

--- a/pybossa/exporter/json_export.py
+++ b/pybossa/exporter/json_export.py
@@ -64,3 +64,4 @@ class JsonExporter(Exporter):
         print "%d (json)" % project.id
         self._make_zip(project, "task")
         self._make_zip(project, "task_run")
+        self._make_zip(project, "result")

--- a/pybossa/jobs.py
+++ b/pybossa/jobs.py
@@ -106,7 +106,7 @@ def get_periodic_jobs(queue):
     # Create ZIPs for all projects
     zip_jobs = get_export_task_jobs(queue) if queue in ('high', 'low') else []
     # Based on type of user
-    project_jobs = get_project_jobs(queue) if queue == ('super', 'maintenance') else []
+    project_jobs = get_project_jobs(queue) if queue in ('super', 'high') else []
     autoimport_jobs = get_autoimport_jobs() if queue == 'low' else []
     # User engagement jobs
     engage_jobs = get_inactive_users_jobs() if queue == 'quaterly' else []
@@ -180,14 +180,13 @@ def get_project_jobs(queue):
     from pybossa.core import project_repo
     from pybossa.cache import projects as cached_projects
     timeout = current_app.config.get('TIMEOUT')
-    #                        get_project_stats,
-    #                        timeout=timeout,
-    #                        queue=queue)
     if queue == 'super':
         projects = cached_projects.get_from_pro_user()
-    else:
+    elif queue == 'high':
         projects = (p.dictize() for p in project_repo.filter_by(published=True)
                     if p.owner.pro is False)
+    else:
+        projects = []
     for project in projects:
         project_id = project.get('id')
         job = dict(name=get_project_stats,

--- a/pybossa/jobs.py
+++ b/pybossa/jobs.py
@@ -189,8 +189,9 @@ def get_project_jobs(queue):
         projects = []
     for project in projects:
         project_id = project.get('id')
+        project_short_name = project.get('short_name')
         job = dict(name=get_project_stats,
-                   args=[project_id], kwargs={},
+                   args=[project_id, project_short_name], kwargs={},
                    timeout=timeout,
                    queue=queue)
         yield job

--- a/pybossa/jobs.py
+++ b/pybossa/jobs.py
@@ -106,7 +106,7 @@ def get_periodic_jobs(queue):
     # Create ZIPs for all projects
     zip_jobs = get_export_task_jobs(queue) if queue in ('high', 'low') else []
     # Based on type of user
-    project_jobs = get_project_jobs() if queue == 'super' else []
+    project_jobs = get_project_jobs(queue) if queue == ('super', 'maintenance') else []
     autoimport_jobs = get_autoimport_jobs() if queue == 'low' else []
     # User engagement jobs
     engage_jobs = get_inactive_users_jobs() if queue == 'quaterly' else []
@@ -175,14 +175,26 @@ def project_export(_id):
         csv_exporter.pregenerate_zip_files(app)
 
 
-def get_project_jobs(queue='super'):
+def get_project_jobs(queue):
     """Return a list of jobs based on user type."""
+    from pybossa.core import project_repo
     from pybossa.cache import projects as cached_projects
     timeout = current_app.config.get('TIMEOUT')
-    return create_dict_jobs(cached_projects.get_from_pro_user(),
-                            get_project_stats,
-                            timeout=timeout,
-                            queue=queue)
+    #                        get_project_stats,
+    #                        timeout=timeout,
+    #                        queue=queue)
+    if queue == 'super':
+        projects = cached_projects.get_from_pro_user()
+    else:
+        projects = (p.dictize() for p in project_repo.filter_by(published=True)
+                    if p.owner.pro is False)
+    for project in projects:
+        project_id = project.get('id')
+        job = dict(name=get_project_stats,
+                   args=[project_id], kwargs={},
+                   timeout=timeout,
+                   queue=queue)
+        yield job
 
 
 def create_dict_jobs(data, function, timeout, queue='low'):
@@ -337,14 +349,7 @@ def get_project_stats(_id, short_name):  # pragma: no cover
     from flask import current_app
 
     cached_projects.get_project(short_name)
-    cached_projects.n_tasks(_id)
-    cached_projects.n_task_runs(_id)
-    cached_projects.overall_progress(_id)
-    cached_projects.last_activity(_id)
-    cached_projects.n_completed_tasks(_id)
-    cached_projects.n_volunteers(_id)
-    cached_projects.browse_tasks(_id)
-    stats.get_stats(_id, current_app.config.get('GEO'))
+    stats.update_stats(_id, current_app.config.get('GEO'))
 
 
 @with_cache_disabled
@@ -384,17 +389,17 @@ def warm_cache():  # pragma: no cover
     def warm_project(_id, short_name, featured=False):
         if _id not in projects_cached:
             cached_projects.get_project(short_name)
-            cached_projects.n_tasks(_id)
-            n_task_runs = cached_projects.n_task_runs(_id)
-            cached_projects.overall_progress(_id)
-            cached_projects.last_activity(_id)
-            cached_projects.n_completed_tasks(_id)
-            cached_projects.n_volunteers(_id)
-            cached_projects.browse_tasks(_id)
-            if n_task_runs >= 1000 or featured:
-                # print ("Getting stats for %s as it has %s task runs" %
-                #        (short_name, n_task_runs))
-                stats.get_stats(_id, app.config.get('GEO'))
+            #cached_projects.n_tasks(_id)
+            #n_task_runs = cached_projects.n_task_runs(_id)
+            #cached_projects.overall_progress(_id)
+            #cached_projects.last_activity(_id)
+            #cached_projects.n_completed_tasks(_id)
+            #cached_projects.n_volunteers(_id)
+            #cached_projects.browse_tasks(_id)
+            #if n_task_runs >= 1000 or featured:
+            #    # print ("Getting stats for %s as it has %s task runs" %
+            #    #        (short_name, n_task_runs))
+            stats.update_stats(_id, app.config.get('GEO'))
             projects_cached.append(_id)
 
     # Cache top projects
@@ -628,12 +633,13 @@ def get_weekly_stats_update_projects():
 
 
 def send_weekly_stats_project(project_id):
-    from pybossa.cache.project_stats import get_stats
+    from pybossa.cache.project_stats import update_stats, get_stats
     from pybossa.core import project_repo
     from datetime import datetime
     project = project_repo.get(project_id)
     if project.owner.subscribed is False:
         return "Owner does not want updates by email"
+    update_stats(project_id)
     dates_stats, hours_stats, users_stats = get_stats(project_id,
                                                       geo=True,
                                                       period='1 week')

--- a/pybossa/model/event_listeners.py
+++ b/pybossa/model/event_listeners.py
@@ -93,6 +93,13 @@ def add_project_event(mapper, conn, target):
     tmp = Project().to_public_json(tmp)
     obj.update(tmp)
     update_feed(obj)
+    # Create a clean projectstats object for it
+    sql_query = """INSERT INTO project_stats 
+                   (project_id, n_tasks, n_task_runs, n_results, n_volunteers,
+                   n_completed_tasks, overall_progress, average_time,
+                   n_blogposts, last_activity, info)
+                   VALUES (%s, 0, 0, 0, 0, 0, 0, 0, 0, 0, '{}');""" % (target.id)
+    conn.execute(sql_query)
 
 
 @event.listens_for(Task, 'after_insert')

--- a/pybossa/model/project_stats.py
+++ b/pybossa/model/project_stats.py
@@ -43,7 +43,7 @@ class ProjectStats(db.Model, DomainObject):
     n_results = Column(Integer, default=0)
     #: Number of volunteers
     n_volunteers = Column(Integer, default=0)
-    #: Number of completed tasks 
+    #: Number of completed tasks
     n_completed_tasks = Column(Integer, default=0)
     #: Overall progress
     overall_progress = Column(Integer, default=0)

--- a/pybossa/model/project_stats.py
+++ b/pybossa/model/project_stats.py
@@ -41,6 +41,10 @@ class ProjectStats(db.Model, DomainObject):
     n_task_runs = Column(Integer, default=0)
     #: Number of results
     n_results = Column(Integer, default=0)
+    #: Number of volunteers
+    n_volunteers = Column(Integer, default=0)
+    #: Number of completed tasks 
+    n_completed_tasks = Column(Integer, default=0)
     #: Overall progress
     overall_progress = Column(Integer, default=0)
     #: Last Activity

--- a/pybossa/model/project_stats.py
+++ b/pybossa/model/project_stats.py
@@ -50,7 +50,7 @@ class ProjectStats(db.Model, DomainObject):
     #: Average time to complete a task
     average_time = Column(Float, default=0)
     #: Number of blog posts
-    n_blogposts= Column(Integer, default=0)
+    n_blogposts = Column(Integer, default=0)
     #: Last Activity
     last_activity = Column(Text, default=make_timestamp)
     #: Stats payload

--- a/pybossa/model/project_stats.py
+++ b/pybossa/model/project_stats.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with PYBOSSA.  If not, see <http://www.gnu.org/licenses/>.
 
-from sqlalchemy import Integer, Text
+from sqlalchemy import Integer, Text, Float
 from sqlalchemy.schema import Column, ForeignKey
 
 from pybossa.core import db
@@ -47,6 +47,8 @@ class ProjectStats(db.Model, DomainObject):
     n_completed_tasks = Column(Integer, default=0)
     #: Overall progress
     overall_progress = Column(Integer, default=0)
+    #: Average time to complete a task
+    average_time = Column(Float, default=0)
     #: Last Activity
     last_activity = Column(Text, default=make_timestamp)
     #: Stats payload

--- a/pybossa/model/project_stats.py
+++ b/pybossa/model/project_stats.py
@@ -30,9 +30,9 @@ class ProjectStats(db.Model, DomainObject):
 
     __tablename__ = 'project_stats'
 
-    #: Webook ID
+    #: ID
     id = Column(Integer, primary_key=True)
-    #: Webhook created (aka triggered)
+    #: Project ID
     project_id = Column(Integer, ForeignKey('project.id', ondelete='CASCADE'),
                         nullable=False)
     #: Number of tasks

--- a/pybossa/model/project_stats.py
+++ b/pybossa/model/project_stats.py
@@ -49,6 +49,8 @@ class ProjectStats(db.Model, DomainObject):
     overall_progress = Column(Integer, default=0)
     #: Average time to complete a task
     average_time = Column(Float, default=0)
+    #: Number of blog posts
+    n_blogposts= Column(Integer, default=0)
     #: Last Activity
     last_activity = Column(Text, default=make_timestamp)
     #: Stats payload

--- a/pybossa/model/project_stats.py
+++ b/pybossa/model/project_stats.py
@@ -1,0 +1,49 @@
+# -*- coding: utf8 -*-
+# This file is part of PYBOSSA.
+#
+# Copyright (C) 2015 Scifabric LTD.
+#
+# PYBOSSA is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PYBOSSA is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with PYBOSSA.  If not, see <http://www.gnu.org/licenses/>.
+
+from sqlalchemy import Integer, Text
+from sqlalchemy.schema import Column, ForeignKey
+
+from pybossa.core import db
+from pybossa.model import DomainObject, make_timestamp
+from sqlalchemy.dialects.postgresql import JSON
+from sqlalchemy.ext.mutable import MutableDict
+
+
+class ProjectStats(db.Model, DomainObject):
+    '''A Table with Project Stats for Projects.'''
+
+    __tablename__ = 'project_stats'
+
+    #: Webook ID
+    id = Column(Integer, primary_key=True)
+    #: Webhook created (aka triggered)
+    project_id = Column(Integer, ForeignKey('project.id', ondelete='CASCADE'),
+                        nullable=False)
+    #: Number of tasks
+    n_tasks = Column(Integer, default=0)
+    #: Number of task runs
+    n_task_runs = Column(Integer, default=0)
+    #: Number of results
+    n_results = Column(Integer, default=0)
+    #: Overall progress
+    overall_progress = Column(Integer, default=0)
+    #: Last Activity
+    last_activity = Column(Text, default=make_timestamp)
+    #: Stats payload
+    info = Column(MutableDict.as_mutable(JSON), default=dict())

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -717,9 +717,7 @@ def delete_autoimporter(short_name):
 
 @blueprint.route('/<short_name>/password', methods=['GET', 'POST'])
 def password_required(short_name):
-    (project, owner, n_tasks, n_task_runs,
-     overall_progress, last_activity,
-     n_results) = project_by_shortname(short_name)
+    project, owner, ps = project_by_shortname(short_name)
     form = PasswordForm(request.form)
     if request.method == 'POST' and form.validate():
         password = request.form.get('password')
@@ -738,9 +736,7 @@ def password_required(short_name):
 
 @blueprint.route('/<short_name>/task/<int:task_id>')
 def task_presenter(short_name, task_id):
-    (project, owner, n_tasks, n_task_runs,
-     overall_progress, last_activity,
-     n_results) = project_by_shortname(short_name)
+    project, owner, ps = project_by_shortname(short_name)
     task = task_repo.get_task(id=task_id)
     if task is None:
         raise abort(404)
@@ -846,9 +842,7 @@ def presenter(short_name):
 
 @blueprint.route('/<short_name>/tutorial')
 def tutorial(short_name):
-    (project, owner, n_tasks, n_task_runs,
-     overall_progress, last_activity,
-     n_results) = project_by_shortname(short_name)
+    project, owner, ps = project_by_shortname(short_name)
     title = project_title(project, "Tutorial")
 
     if project.needs_password():
@@ -870,9 +864,7 @@ def tutorial(short_name):
 def export(short_name, task_id):
     """Return a file with all the TaskRuns for a given Task"""
     # Check if the project exists
-    (project, owner, n_tasks, n_task_runs,
-     overall_progress, last_activity,
-     n_results) = project_by_shortname(short_name)
+    project, owner, ps = project_by_shortname(short_name)
 
     if project.needs_password():
         redirect_to_password = _check_if_redirect_to_password(project)

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -1208,8 +1208,7 @@ def show_stats(short_name):
 
     project_dict = add_custom_contrib_button_to(project, get_user_id_or_ip(),
                                                 ps=ps)
-    contrib_time = ps.average_time
-    formatted_contrib_time = round(contrib_time, 2)
+    formatted_contrib_time = round(ps.average_time, 2)
 
     project_sanitized, owner_sanitized = sanitize_project_owner(project, owner,
                                                                 current_user)

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -127,11 +127,7 @@ def project_by_shortname(short_name):
         #        cached_projects.n_results(project.id))
         return (project,
                 owner,
-                ps.n_tasks,
-                ps.n_task_runs,
-                ps.overall_progress,
-                ps.last_activity,
-                ps.n_results)
+                ps)
     else:
         cached_projects.delete_project(short_name)
         return abort(404)
@@ -1193,9 +1189,10 @@ def export_to(short_name):
 @blueprint.route('/<short_name>/stats')
 def show_stats(short_name):
     """Returns Project Stats"""
-    (project, owner, n_tasks, n_task_runs,
-     overall_progress, last_activity,
-     n_results) = project_by_shortname(short_name)
+    #(project, owner, n_tasks, n_task_runs,
+    # overall_progress, last_activity,
+    # n_results) = project_by_shortname(short_name)
+    project, owner, ps = project_by_shortname(short_name)
     n_volunteers = cached_projects.n_volunteers(project.id)
     n_completed_tasks = cached_projects.n_completed_tasks(project.id)
     title = project_title(project, "Statistics")
@@ -1210,16 +1207,16 @@ def show_stats(short_name):
 
     project_sanitized, owner_sanitized = sanitize_project_owner(project, owner, current_user)
 
-    if not ((n_tasks > 0) and (n_task_runs > 0)):
+    if not ((ps.n_tasks > 0) and (ps.n_task_runs > 0)):
         project = add_custom_contrib_button_to(project, get_user_id_or_ip())
         response = dict(template='/projects/non_stats.html',
                         title=title,
                         project=project_sanitized,
                         owner=owner_sanitized,
-                        n_tasks=n_tasks,
-                        overall_progress=overall_progress,
-                        n_volunteers=n_volunteers,
-                        n_completed_tasks=n_completed_tasks,
+                        n_tasks=ps.n_tasks,
+                        overall_progress=ps.overall_progress,
+                        n_volunteers=ps.n_volunteers,
+                        n_completed_tasks=ps.n_completed_tasks,
                         pro_features=pro)
         return handle_content_type(response)
 
@@ -1273,10 +1270,10 @@ def show_stats(short_name):
                     userStats=userStats,
                     project=project_sanitized,
                     owner=owner_sanitized,
-                    n_tasks=n_tasks,
-                    overall_progress=overall_progress,
-                    n_volunteers=n_volunteers,
-                    n_completed_tasks=n_completed_tasks,
+                    n_tasks=ps.n_tasks,
+                    overall_progress=ps.overall_progress,
+                    n_volunteers=ps.n_volunteers,
+                    n_completed_tasks=ps.n_completed_tasks,
                     avg_contrib_time=formatted_contrib_time,
                     pro_features=pro)
 

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -895,9 +895,7 @@ def export(short_name, task_id):
 
 @blueprint.route('/<short_name>/tasks/')
 def tasks(short_name):
-    (project, owner, n_tasks, n_task_runs,
-     overall_progress, last_activity,
-     n_results) = project_by_shortname(short_name)
+    project, owner, ps = project_by_shortname(short_name)
     title = project_title(project, "Tasks")
 
     if project.needs_password():
@@ -984,9 +982,7 @@ def tasks_browse(short_name, page=1):
 @login_required
 def delete_tasks(short_name):
     """Delete ALL the tasks for a given project"""
-    (project, owner, n_tasks, n_task_runs,
-     overall_progress, last_activity,
-     n_results) = project_by_shortname(short_name)
+    project, owner, ps = project_by_shortname(short_name)
     ensure_authorized_to('read', project)
     ensure_authorized_to('update', project)
     pro = pro_features()

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -326,7 +326,7 @@ def task_presenter_editor(short_name):
             wrap = lambda i: "projects/presenters/%s.html" % i
             pres_tmpls = map(wrap, current_app.config.get('PRESENTERS'))
 
-            project = add_custom_contrib_button_to(project, get_user_id_or_ip())
+            project = add_custom_contrib_button_to(project, get_user_id_or_ip(), ps=ps)
             project_sanitized, owner_sanitized = sanitize_project_owner(project,
                                                                         owner,
                                                                         current_user)
@@ -492,7 +492,7 @@ def update(short_name):
                       'error')
             return redirect_content_type(url_for('.update', short_name=short_name))
 
-    project = add_custom_contrib_button_to(project, get_user_id_or_ip())
+    project = add_custom_contrib_button_to(project, get_user_id_or_ip(), ps=ps)
     project_sanitized, owner_sanitized = sanitize_project_owner(project, owner, current_user)
     response = dict(template='/projects/update.html',
                     form=form,
@@ -525,7 +525,7 @@ def details(short_name):
     pro = pro_features()
 
     title = project_title(project, None)
-    project = add_custom_contrib_button_to(project, get_user_id_or_ip())
+    project = add_custom_contrib_button_to(project, get_user_id_or_ip(), ps=ps)
     project_sanitized, owner_sanitized = sanitize_project_owner(project, owner, current_user)
     template_args = {"project": project_sanitized,
                      "title": title,
@@ -554,7 +554,7 @@ def settings(short_name):
     ensure_authorized_to('read', project)
     ensure_authorized_to('update', project)
     pro = pro_features()
-    project = add_custom_contrib_button_to(project, get_user_id_or_ip())
+    project = add_custom_contrib_button_to(project, get_user_id_or_ip(), ps=ps)
     owner_serialized = cached_users.get_user_summary(owner.name)
     response = dict(template='/projects/settings.html',
                     project=project,
@@ -581,7 +581,7 @@ def import_task(short_name):
     title = project_title(project, "Import Tasks")
     loading_text = gettext("Importing tasks, this may take a while, wait...")
     pro = pro_features()
-    dict_project = add_custom_contrib_button_to(project, get_user_id_or_ip())
+    dict_project = add_custom_contrib_button_to(project, get_user_id_or_ip(), ps=ps)
     project_sanitized, owner_sanitized = sanitize_project_owner(dict_project, owner, current_user)
     template_args = dict(title=title, loading_text=loading_text,
                          project=project_sanitized,
@@ -652,7 +652,7 @@ def setup_autoimporter(short_name):
 
     project, owner, ps = project_by_shortname(short_name)
 
-    dict_project = add_custom_contrib_button_to(project, get_user_id_or_ip())
+    dict_project = add_custom_contrib_button_to(project, get_user_id_or_ip(), ps=ps)
     template_args = dict(project=dict_project,
                          owner=owner,
                          n_tasks=ps.n_tasks,
@@ -726,7 +726,7 @@ def password_required(short_name):
         passwd_mngr = ProjectPasswdManager(CookieHandler(request, signer, cookie_exp))
         if passwd_mngr.validates(password, project):
             response = make_response(redirect(request.args.get('next')))
-            return passwd_mngr.update_response(response, project, get_user_id_or_ip())
+            return passwd_mngr.update_response(response, project, get_user_id_or_ip(), ps=ps)
         flash(gettext('Sorry, incorrect password'))
     return render_template('projects/password.html',
                             project=project,
@@ -900,7 +900,7 @@ def tasks(short_name):
         ensure_authorized_to('read', project)
 
     pro = pro_features()
-    project = add_custom_contrib_button_to(project, get_user_id_or_ip())
+    project = add_custom_contrib_button_to(project, get_user_id_or_ip(), ps=ps)
     feature_handler = ProFeatureHandler(current_app.config.get('PRO_FEATURES'))
     autoimporter_enabled = feature_handler.autoimporter_enabled_for(current_user)
 
@@ -965,7 +965,7 @@ def tasks_browse(short_name, page=1):
             return redirect_to_password
     else:
         ensure_authorized_to('read', project)
-    project = add_custom_contrib_button_to(project, get_user_id_or_ip())
+    project = add_custom_contrib_button_to(project, get_user_id_or_ip(), ps=ps)
     return respond()
 
 
@@ -980,7 +980,7 @@ def delete_tasks(short_name):
     pro = pro_features()
     if request.method == 'GET':
         title = project_title(project, "Delete")
-        project = add_custom_contrib_button_to(project, get_user_id_or_ip())
+        project = add_custom_contrib_button_to(project, get_user_id_or_ip(), ps=ps)
         project_sanitized, owner_sanitized = sanitize_project_owner(project, 
                                                                     owner, 
                                                                     current_user)
@@ -1121,7 +1121,7 @@ def export_to(short_name):
     if not (fmt and ty):
         if len(request.args) >= 1:
             abort(404)
-        project = add_custom_contrib_button_to(project, get_user_id_or_ip())
+        project = add_custom_contrib_button_to(project, get_user_id_or_ip(), ps=ps)
         return respond()
 
     if fmt not in export_formats:
@@ -1136,7 +1136,8 @@ def export_to(short_name):
         if task_run:
             ensure_authorized_to('read', task_run)
 
-    return {"json": respond_json, "csv": respond_csv, 'ckan': respond_ckan}[fmt](ty)
+    return {"json": respond_json, "csv": respond_csv,
+            'ckan': respond_ckan}[fmt](ty)
 
 
 @blueprint.route('/<short_name>/stats')
@@ -1243,7 +1244,7 @@ def task_settings(short_name):
     ensure_authorized_to('read', project)
     ensure_authorized_to('update', project)
     pro = pro_features()
-    project = add_custom_contrib_button_to(project, get_user_id_or_ip())
+    project = add_custom_contrib_button_to(project, get_user_id_or_ip(), ps=ps)
     return render_template('projects/task_settings.html',
                            project=project,
                            owner=owner,
@@ -1412,7 +1413,7 @@ def show_blogposts(short_name):
     else:
         ensure_authorized_to('read', Blogpost, project_id=project.id)
     pro = pro_features()
-    project = add_custom_contrib_button_to(project, get_user_id_or_ip())
+    project = add_custom_contrib_button_to(project, get_user_id_or_ip(), ps=ps)
 
     project_sanitized, owner_sanitized = sanitize_project_owner(project, owner, current_user)
 
@@ -1445,7 +1446,7 @@ def show_blogpost(short_name, id):
     else:
         ensure_authorized_to('read', blogpost)
     pro = pro_features()
-    project = add_custom_contrib_button_to(project, get_user_id_or_ip())
+    project = add_custom_contrib_button_to(project, get_user_id_or_ip(), ps=ps)
     return render_template('projects/blog_post.html',
                            project=project,
                            owner=owner,
@@ -1464,7 +1465,7 @@ def new_blogpost(short_name):
     pro = pro_features()
 
     def respond():
-        dict_project = add_custom_contrib_button_to(project, get_user_id_or_ip())
+        dict_project = add_custom_contrib_button_to(project, get_user_id_or_ip(), ps=ps)
         response = dict(template='projects/new_blogpost.html',
                         title=gettext("Write a new post"),
                         form=form,
@@ -1574,7 +1575,7 @@ def delete_blogpost(short_name, id):
 def _check_if_redirect_to_password(project):
     cookie_exp = current_app.config.get('PASSWD_COOKIE_TIMEOUT')
     passwd_mngr = ProjectPasswdManager(CookieHandler(request, signer, cookie_exp))
-    if passwd_mngr.password_needed(project, get_user_id_or_ip()):
+    if passwd_mngr.password_needed(project, get_user_id_or_ip(), ps=ps):
         return redirect(url_for('.password_required',
                                 short_name=project.short_name, next=request.path))
 
@@ -1591,7 +1592,7 @@ def auditlog(short_name):
 
     ensure_authorized_to('read', Auditlog, project_id=project.id)
     logs = auditlogger.get_project_logs(project.id)
-    project = add_custom_contrib_button_to(project, get_user_id_or_ip())
+    project = add_custom_contrib_button_to(project, get_user_id_or_ip(), ps=ps)
     return render_template('projects/auditlog.html', project=project,
                            owner=owner, logs=logs,
                            overall_progress=ps.overall_progress,
@@ -1685,7 +1686,7 @@ def webhook_handler(short_name, oid=None):
     redirect_to_password = _check_if_redirect_to_password(project)
     if redirect_to_password:
         return redirect_to_password
-    project = add_custom_contrib_button_to(project, get_user_id_or_ip())
+    project = add_custom_contrib_button_to(project, get_user_id_or_ip(), ps=ps)
     return render_template('projects/webhook.html', project=project,
                            owner=owner, responses=responses,
                            overall_progress=ps.overall_progress,
@@ -1709,7 +1710,7 @@ def results(short_name):
     pro = pro_features()
 
     title = project_title(project, None)
-    project = add_custom_contrib_button_to(project, get_user_id_or_ip())
+    project = add_custom_contrib_button_to(project, get_user_id_or_ip(), ps=ps)
 
     project_sanitized, owner_sanitized = sanitize_project_owner(project, owner, current_user)
 

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -1146,6 +1146,8 @@ def show_stats(short_name):
     title = project_title(project, "Statistics")
     pro = pro_features(owner)
 
+    stats.update_stats(project.id)
+
     if project.needs_password():
         redirect_to_password = _check_if_redirect_to_password(project)
         if redirect_to_password:
@@ -1201,8 +1203,8 @@ def show_stats(short_name):
         hourStats=hours_stats)
 
     project_dict = add_custom_contrib_button_to(project, get_user_id_or_ip())
-    contrib_time = cached_projects.average_contribution_time(project.id)
-    formatted_contrib_time = round(contrib_time.total_seconds(), 2)
+    contrib_time = ps.average_time
+    formatted_contrib_time = round(contrib_time, 2)
 
     project_sanitized, owner_sanitized = sanitize_project_owner(project, owner, current_user)
 

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -807,9 +807,7 @@ def presenter(short_name):
         resp = make_response(render_template(tmpl, **template_args))
         return resp
 
-    (project, owner, n_tasks, n_task_runs,
-     overall_progress, last_activity,
-     n_results) = project_by_shortname(short_name)
+    project, owner, ps = project_by_shortname(short_name)
 
     if project.needs_password():
         redirect_to_password = _check_if_redirect_to_password(project)
@@ -919,14 +917,12 @@ def tasks(short_name):
                     project=project_sanitized,
                     owner=owner_sanitized,
                     autoimporter_enabled=autoimporter_enabled,
-                    n_tasks=n_tasks,
-                    n_task_runs=n_task_runs,
-                    overall_progress=overall_progress,
-                    last_activity=last_activity,
-                    n_completed_tasks=cached_projects.n_completed_tasks(
-                        project.get('id')),
-                    n_volunteers=cached_projects.n_volunteers(
-                        project.get('id')),
+                    n_tasks=ps.n_tasks,
+                    n_task_runs=ps.n_task_runs,
+                    overall_progress=ps.overall_progress,
+                    last_activity=ps.last_activity,
+                    n_completed_tasks=ps.n_completed_tasks,
+                    n_volunteers=ps.n_volunteers,
                     pro_features=pro)
 
     return handle_content_type(response)
@@ -934,12 +930,8 @@ def tasks(short_name):
 @blueprint.route('/<short_name>/tasks/browse')
 @blueprint.route('/<short_name>/tasks/browse/<int:page>')
 def tasks_browse(short_name, page=1):
-    (project, owner, n_tasks, n_task_runs,
-     overall_progress, last_activity,
-     n_results) = project_by_shortname(short_name)
+    project, owner, ps = project_by_shortname(short_name)
     title = project_title(project, "Tasks")
-    n_volunteers = cached_projects.n_volunteers(project.id)
-    n_completed_tasks = cached_projects.n_completed_tasks(project.id)
     pro = pro_features()
 
     def respond():
@@ -960,10 +952,10 @@ def tasks_browse(short_name, page=1):
                     tasks=page_tasks,
                     title=title,
                     pagination=pagination,
-                    n_tasks=n_tasks,
-                    overall_progress=overall_progress,
-                    n_volunteers=n_volunteers,
-                    n_completed_tasks=n_completed_tasks,
+                    n_tasks=ps.n_tasks,
+                    overall_progress=ps.overall_progress,
+                    n_volunteers=ps.n_volunteers,
+                    n_completed_tasks=ps.n_completed_tasks,
                     pro_features=pro)
 
         return handle_content_type(data)

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -1002,7 +1002,7 @@ def delete_tasks(short_name):
 def export_to(short_name):
     """Export Tasks and TaskRuns in the given format"""
     project, owner, ps = project_by_shortname(short_name)
-    suppported_tables = ['task', 'task_run', 'result']
+    supported_tables = ['task', 'task_run', 'result']
 
     title = project_title(project, gettext("Export"))
     loading_text = gettext("Exporting data..., this may take a while")

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -589,7 +589,7 @@ def import_task(short_name):
                          n_tasks=ps.n_tasks,
                          overall_progress=ps.overall_progress,
                          n_volunteers=ps.n_volunteers,
-                         n_completed_tasks=n_completed_tasks,
+                         n_completed_tasks=ps.n_completed_tasks,
                          target='project.import_task',
                          pro_features=pro)
 
@@ -657,8 +657,8 @@ def setup_autoimporter(short_name):
                          owner=owner,
                          n_tasks=ps.n_tasks,
                          overall_progress=ps.overall_progress,
-                         n_volunteers=n_volunteers,
-                         n_completed_tasks=n_completed_tasks,
+                         n_volunteers=ps.n_volunteers,
+                         n_completed_tasks=ps.n_completed_tasks,
                          pro_features=pro,
                          target='project.setup_autoimporter')
     ensure_authorized_to('read', project)
@@ -936,7 +936,7 @@ def tasks_browse(short_name, page=1):
     def respond():
         per_page = 10
         offset = (page - 1) * per_page
-        count = n_tasks
+        count = ps.n_tasks
         page_tasks = cached_projects.browse_tasks(project.get('id'), per_page, offset)
         if not page_tasks and page != 1:
             abort(404)
@@ -953,8 +953,8 @@ def tasks_browse(short_name, page=1):
                     pagination=pagination,
                     n_tasks=ps.n_tasks,
                     overall_progress=ps.overall_progress,
-                    n_volunteers=n_volunteers,
-                    n_completed_tasks=n_completed_tasks,
+                    n_volunteers=ps.n_volunteers,
+                    n_completed_tasks=ps.n_completed_tasks,
                     pro_features=pro)
 
         return handle_content_type(data)
@@ -989,8 +989,8 @@ def delete_tasks(short_name):
                         owner=owner_sanitized,
                         n_tasks=ps.n_tasks,
                         n_task_runs=ps.n_task_runs,
-                        n_volunteers=n_volunteers,
-                        n_completed_tasks=n_completed_tasks,
+                        n_volunteers=ps.n_volunteers,
+                        n_completed_tasks=ps.n_completed_tasks,
                         overall_progress=ps.overall_progress,
                         last_activity=ps.last_activity,
                         title=title,
@@ -1029,8 +1029,8 @@ def export_to(short_name):
                                owner=owner,
                                n_tasks=ps.n_tasks,
                                n_task_runs=ps.n_task_runs,
-                               n_volunteers=n_volunteers,
-                               n_completed_tasks=n_completed_tasks,
+                               n_volunteers=ps.n_volunteers,
+                               n_completed_tasks=ps.n_completed_tasks,
                                overall_progress=ps.overall_progress,
                                pro_features=pro)
 
@@ -1250,8 +1250,8 @@ def task_settings(short_name):
                            owner=owner,
                            n_tasks=ps.n_tasks,
                            overall_progress=ps.overall_progress,
-                           n_volunteers=n_volunteers,
-                           n_completed_tasks=n_completed_tasks,
+                           n_volunteers=ps.n_volunteers,
+                           n_completed_tasks=ps.n_completed_tasks,
                            pro_features=pro)
 
 
@@ -1575,7 +1575,7 @@ def delete_blogpost(short_name, id):
 def _check_if_redirect_to_password(project):
     cookie_exp = current_app.config.get('PASSWD_COOKIE_TIMEOUT')
     passwd_mngr = ProjectPasswdManager(CookieHandler(request, signer, cookie_exp))
-    if passwd_mngr.password_needed(project, get_user_id_or_ip(), ps=ps):
+    if passwd_mngr.password_needed(project, get_user_id_or_ip()):
         return redirect(url_for('.password_required',
                                 short_name=project.short_name, next=request.path))
 
@@ -1717,14 +1717,14 @@ def results(short_name):
     template_args = {"project": project_sanitized,
                      "title": title,
                      "owner": owner_sanitized,
-                     "n_tasks": n_tasks,
-                     "n_task_runs": n_task_runs,
-                     "overall_progress": overall_progress,
-                     "last_activity": last_activity,
+                     "n_tasks": ps.n_tasks,
+                     "n_task_runs": ps.n_task_runs,
+                     "overall_progress": ps.overall_progress,
+                     "last_activity": ps.last_activity,
                      "n_completed_tasks": ps.n_completed_tasks,
                      "n_volunteers": ps.n_volunteers,
                      "pro_features": pro,
-                     "n_results": n_results}
+                     "n_results": ps.n_results}
 
     response = dict(template = '/projects/results.html', **template_args)
 

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ requirements = [
 
 setup(
     name = 'pybossa',
-    version = '2.4.3',
+    version = '2.5.0',
     packages = find_packages(),
     install_requires = requirements,
     # only needed when installing directly from setup.py (PyPi, eggs?) and pointing to e.g. a git repo.

--- a/test/test_cache/test_cache_helpers.py
+++ b/test/test_cache/test_cache_helpers.py
@@ -20,6 +20,7 @@ from default import Test, db, with_context
 from factories import (ProjectFactory, TaskFactory, TaskRunFactory,
                       AnonymousTaskRunFactory, UserFactory)
 from pybossa.cache import helpers
+from pybossa.cache.project_stats import update_stats
 
 
 class TestHelpersCache(Test):
@@ -163,6 +164,7 @@ class TestHelpersCache(Test):
         user = UserFactory.create()
         TaskRunFactory.create_batch(1, task=task, user=user)
 
+        update_stats(project.id)
         contributing_state = helpers.check_contributing_state(project=project,
                                                               user_id=user.id)
 
@@ -177,7 +179,7 @@ class TestHelpersCache(Test):
         task = TaskFactory.create(project=project, n_answers=2)
         TaskRunFactory.create_batch(2, task=task)
         user = UserFactory.create()
-
+        update_stats(project.id)
         contributing_state = helpers.check_contributing_state(project=project,
                                                               user_id=user.id)
 

--- a/test/test_cache/test_cache_projects.py
+++ b/test/test_cache/test_cache_projects.py
@@ -24,6 +24,7 @@ from mock import patch
 import datetime
 from pybossa.core import result_repo
 from pybossa.model.project import Project
+from pybossa.cache.project_stats import update_stats
 
 
 class TestProjectsCache(Test):
@@ -613,7 +614,7 @@ class TestProjectsCache(Test):
         now = datetime.datetime.utcnow()
         TaskRunFactory.create(task=task, created=now, finish_time=now+first_task_time)
         TaskRunFactory.create(task=task, created=now, finish_time=now+second_task_time)
-
+        update_stats(project.id)
         average_time = cached_projects.average_contribution_time(project.id)
 
-        assert average_time == expected_average_time, average_time
+        assert average_time == expected_average_time.total_seconds(), average_time

--- a/test/test_jobs/__init__.py
+++ b/test/test_jobs/__init__.py
@@ -118,7 +118,7 @@ class TestJobs(Test):
         # Does not call unnecessary functions for performance
         assert non_contr.called == False
         assert inactive.called == False
-        assert project.called == False
+        assert project.called == True
         assert autoimport.called == False
 
     @with_context

--- a/test/test_jobs/test_project_stats.py
+++ b/test/test_jobs/test_project_stats.py
@@ -55,7 +55,7 @@ class TestProjectsStats(Test):
         """Test JOB get project jobs works."""
         user = UserFactory.create(pro=True)
         project = ProjectFactory.create(owner=user)
-        jobs_generator = get_project_jobs()
+        jobs_generator = get_project_jobs('super')
         jobs = []
         for job in jobs_generator:
             jobs.append(job)
@@ -74,14 +74,15 @@ class TestProjectsStats(Test):
     @with_context
     def test_get_project_jobs_for_non_pro_users(self):
         """Test JOB get project jobs works for non pro users."""
-        ProjectFactory.create()
-        jobs_generator = get_project_jobs()
+        owner = UserFactory.create(pro=False)
+        ProjectFactory.create(owner=owner)
+        jobs_generator = get_project_jobs('high')
         jobs = []
         for job in jobs_generator:
             jobs.append(job)
 
-        err_msg = "There should be only 0 jobs"
-        assert len(jobs) == 0, err_msg
+        err_msg = "There should be only 1 jobs"
+        assert len(jobs) == 1, err_msg
 
     @with_context
     def test_warm_project(self):

--- a/test/test_stats.py
+++ b/test/test_stats.py
@@ -106,6 +106,7 @@ class TestStats(Test):
         auth = 0
         TaskRunFactory.create(task=self.project.tasks[0])
         TaskRunFactory.create(task=self.project.tasks[1])
+        stats.update_stats(self.project.id)
         dates_stats, hours_stats, user_stats = stats.get_stats(self.project.id)
         for item in dates_stats:
             if item['label'] == 'Anon + Auth':

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -6510,6 +6510,8 @@ class TestWeb(web.Helper):
         result = result_repo.get_by(project_id=project.id)
         result.info = dict(foo='bar')
         result_repo.update(result)
+        from pybossa.cache.project_stats import update_stats
+        update_stats(project.id)
         res = self.app.get(url, follow_redirects=True)
         assert "The results" in res.data, res.data
 

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -280,6 +280,7 @@ class TestWeb(web.Helper):
 
         # With stats
         url = '/project/%s/stats' % project.short_name
+        update_stats(project.id)
         res = self.app.get(url)
         assert res.status_code == 200, res.status_code
         assert "Distribution" in res.data, res.data
@@ -440,6 +441,7 @@ class TestWeb(web.Helper):
         pro_owned_project = ProjectFactory.create(owner=pro_owner)
         task = TaskFactory.create(project=pro_owned_project)
         TaskRunFactory.create(task=task)
+        update_stats(task.project.id)
         pro_url = '/project/%s/stats' % pro_owned_project.short_name
         res = self.app.get(pro_url)
         assert_raises(ValueError, json.loads, res.data)
@@ -451,6 +453,7 @@ class TestWeb(web.Helper):
         pro_owned_project = ProjectFactory.create(owner=pro_owner)
         task = TaskFactory.create(project=pro_owned_project)
         TaskRunFactory.create(task=task)
+        update_stats(task.project.id)
         pro_url = '/project/%s/stats' % pro_owned_project.short_name
 
         res = self.app_get_json(pro_url)
@@ -6424,6 +6427,7 @@ class TestWeb(web.Helper):
         project = ProjectFactory.create(owner=user)
         task = TaskFactory.create(project=project, n_answers=1)
         taskrun = TaskRunFactory.create(task=task, user=user)
+        update_stats(project.id)
         res = self.app.get('/project/%s/newtask' % project.short_name)
 
         assert task.state == 'completed', task.state

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -339,11 +339,14 @@ class TestWeb(web.Helper):
             self.app_get_json('api/project/%s/newtask' % project.id)
 
         # With stats
+        from pybossa.cache.project_stats import update_stats
+        update_stats(project.id)
+
         url = '/project/%s/stats' % project.short_name
         res = self.app_get_json(url)
         data = json.loads(res.data)
         err_msg = 'Field missing in JSON response'
-        assert 'avg_contrib_time' in data, err_msg
+        assert 'avg_contrib_time' in data, (err_msg, data.keys())
         assert 'n_completed_tasks' in data, err_msg
         assert 'n_tasks' in data, err_msg
         assert 'n_volunteers' in data, err_msg


### PR DESCRIPTION
PYBOSSA has been using Redis to store this information, however this becomes "problematic" when there are millions of rows in the database, as a cold start will make things really slow. Thus, instead of using a materialized view (this cannot be used because we've tons of different SQL queries that cannot fit into one query) we'll use the same code as before but storing the info in a new table. This will make things much faster.