### PR TITLE
Fix #1641.

### DIFF
--- a/pybossa/view/leaderboard.py
+++ b/pybossa/view/leaderboard.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with PYBOSSA.  If not, see <http://www.gnu.org/licenses/>.
 """Leaderboard view for PYBOSSA."""
-from flask import Blueprint, current_app, request
+from flask import Blueprint, current_app, request, abort
 from flask.ext.login import current_user
 from pybossa.cache import users as cached_users
 from pybossa.util import handle_content_type
@@ -36,11 +36,20 @@ def index(window=0):
     if window >= 10:
         window = 10
 
+    info = request.args.get('info')
+
+    leaderboards = current_app.config.get('LEADERBOARDS')
+
+    if leaderboards is None and info:
+        return abort(404)
+
+    if leaderboards and info not in leaderboards:
+        return abort(404)
 
     top_users = cached_users.get_leaderboard(current_app.config['LEADERBOARD'],
                                              user_id=user_id,
                                              window=window,
-                                             info=request.args.get('info'))
+                                             info=info)
 
     response = dict(template='/stats/index.html',
                     title="Community Leaderboard",

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -227,30 +227,37 @@ class TestWeb(web.Helper):
         assert len(leaders) == (20+10+1+10), len(leaders)
         assert leaders[30]['name'] == user.name
 
-        res = self.app_get_json('/leaderboard/?info=n')
-        data = json.loads(res.data)
-        err_msg = 'Top users missing'
-        assert 'top_users' in data, err_msg
-        err_msg = 'leaderboard user information missing'
-        leaders = data['top_users']
-        assert len(leaders) == (20), len(leaders)
-        score = 10
-        rank = 1
-        for u in leaders[0:10]:
-            assert u['score'] == score, u
-            assert u['rank'] == rank, u
-            score = score - 1
-            rank = rank + 1
+        res = self.app_get_json('/leaderboard/?info=noleaderboards')
+        assert res.status_code == 404,  res.status_code
 
-        res = self.app_get_json('/leaderboard/window/3?api_key=%s&info=n' % user.api_key)
-        data = json.loads(res.data)
-        err_msg = 'Top users missing'
-        assert 'top_users' in data, err_msg
-        err_msg = 'leaderboard user information missing'
-        leaders = data['top_users']
-        assert len(leaders) == (20+3+1+3), len(leaders)
-        assert leaders[23]['name'] == user.name
-        assert leaders[23]['score'] == 0
+        with patch.dict(self.flask_app.config, {'LEADERBOARDS': ['n']}):
+            res = self.app_get_json('/leaderboard/?info=n')
+            data = json.loads(res.data)
+            err_msg = 'Top users missing'
+            assert 'top_users' in data, err_msg
+            err_msg = 'leaderboard user information missing'
+            leaders = data['top_users']
+            assert len(leaders) == (20), len(leaders)
+            score = 10
+            rank = 1
+            for u in leaders[0:10]:
+                assert u['score'] == score, u
+                assert u['rank'] == rank, u
+                score = score - 1
+                rank = rank + 1
+
+            res = self.app_get_json('/leaderboard/window/3?api_key=%s&info=n' % user.api_key)
+            data = json.loads(res.data)
+            err_msg = 'Top users missing'
+            assert 'top_users' in data, err_msg
+            err_msg = 'leaderboard user information missing'
+            leaders = data['top_users']
+            assert len(leaders) == (20+3+1+3), len(leaders)
+            assert leaders[23]['name'] == user.name
+            assert leaders[23]['score'] == 0
+
+            res = self.app_get_json('/leaderboard/?info=new')
+            assert res.status_code == 404,  res.status_code
 
 
     @with_context


### PR DESCRIPTION
Return 404 if the leaderboard is not configured in the settings file.