### PR TITLE
Remove 'response_type' from request_token_params

### DIFF
--- a/pybossa/view/google.py
+++ b/pybossa/view/google.py
@@ -39,9 +39,7 @@ def login():  # pragma: no cover
     """Login with Google."""
     if not current_app.config.get('LDAP_HOST', False):
         if request.args.get("next"):
-            request_token_params = {
-                'scope': 'profile email',
-                'response_type': 'code'}
+            request_token_params = {'scope': 'profile email'}
             google.oauth.request_token_params = request_token_params
         callback = url_for('.oauth_authorized',
                            _external=True)

--- a/test/test_view/test_google.py
+++ b/test/test_view/test_google.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with PYBOSSA.  If not, see <http://www.gnu.org/licenses/>.
 from default import Test, with_context
-from pybossa.view.google import manage_user, manage_user_login
+from pybossa.view.google import manage_user, manage_user_login, google
 from mock import patch
 from factories import UserFactory
 
@@ -170,3 +170,12 @@ class TestGoogle(Test):
         manage_user_login(None, user_data, next_url=next_url)
         assert login_user.called is False
         url_for_app_type.assert_called_with('account.signin')
+
+    @with_context
+    @patch('pybossa.view.google.url_for', return_value=True)
+    def test_request_token_params_set_correctly_with_next(self, url_for):
+        self.app.get('/google/?next=somewhere')
+        assert google.oauth.request_token_params == {
+            'scope': 'profile email'
+        }
+        url_for.assert_called_with('.oauth_authorized', _external=True)


### PR DESCRIPTION
Fix #1672 