### PR TITLE
Add category_id to project public fields

### DIFF
--- a/pybossa/model/project.py
+++ b/pybossa/model/project.py
@@ -123,7 +123,7 @@ class Project(db.Model, DomainObject):
     def public_attributes(self):
         """Return a list of public attributes."""
         return ['id', 'description', 'info', 'n_tasks', 'n_volunteers', 'name',
-                'overall_progress', 'short_name', 'created',
+                'overall_progress', 'short_name', 'created', 'category_id',
                 'long_description', 'last_activity', 'last_activity_raw',
                 'n_task_runs', 'n_results', 'owner', 'updated', 'featured',
                 'owner_id', 'n_completed_tasks', 'n_blogposts', 'owners_ids']


### PR DESCRIPTION
This is a quick fix for a situation where I have the project and need to retrieve its associated category. Hopefully there's no reason why we shouldn't add this.