### PR TITLE
Make the exporter more flexible.

### DIFF
--- a/pybossa/exporter/__init__.py
+++ b/pybossa/exporter/__init__.py
@@ -66,8 +66,6 @@ class Exporter(object):
                             datum[new_key] = row.id
                             tmp.append(flatten(datum,
                                                root_keys_to_ignore=ignore_keys))
-                    # else:
-                    #     tmp.append({'info': inf})
             else:
                 tmp = []
                 for row in data:
@@ -104,7 +102,6 @@ class Exporter(object):
 
     def _project_name_latin_encoded(self, project):
         """project short name for later HTML header usage"""
-        # name = project.short_name.encode('utf-8', 'ignore').decode('latin-1')
         name = unidecode(project.short_name)
         return name
 

--- a/settings_local.py.tmpl
+++ b/settings_local.py.tmpl
@@ -265,3 +265,8 @@ LIBSASS_STYLE = 'compressed'
 # 	    "^/static/.*"
 # 	]
 # }
+# Specify which key from the info field of task, task_run or result is going to be used as the root key
+# for exporting in CSV format
+# TASK_CSV_EXPORT_INFO_KEY = 'key'
+# TASK_RUN_CSV_EXPORT_INFO_KEY = 'key2'
+# RESULT_CSV_EXPORT_INFO_KEY = 'key3'

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -4440,10 +4440,13 @@ class TestWeb(web.Helper):
                     .filter_by(project_id=project.id).all()
         for t in results:
             err_msg = "All the result column names should be included"
+            print t
             d = t.dictize()
             task_run_ids = d['task_run_ids']
             fl = flatten(t.dictize(), root_keys_to_ignore='task_run_ids')
             fl['task_run_ids'] = task_run_ids
+            # keys.append('result_id')
+            print fl
             for tk in fl.keys():
                 expected_key = "%s" % tk
                 assert expected_key in keys, (err_msg, expected_key, keys)


### PR DESCRIPTION
This PR allows to specify a key from the task.info task_run.info or
result.info to be used as the root key when exporting the data as CSV.

For example, you could have in the task_runs the following:

```json
info: answer: [{foo: 1}]
```
And another one like this:

```json
info: {answer:[{foo: 1}, {foo: 2}]}
```

In such cases, you may want to tell PYBOSSA to use answer within info as
the root to flatten the data.