### PR TITLE
enable user_ip via API, PEP8

### DIFF
--- a/pybossa/api/task_run.py
+++ b/pybossa/api/task_run.py
@@ -75,7 +75,7 @@ class TaskRunAPI(APIBase):
             raise Forbidden('You must request a task first!')
 
     def _add_user_info(self, taskrun):
-        if current_user.is_anonymous():
+        if current_user.is_anonymous() and taskrun.user_ip is None:
             taskrun.user_ip = request.remote_addr
             if taskrun.user_ip is None:
                 taskrun.user_ip = '127.0.0.1'

--- a/pybossa/model/task.py
+++ b/pybossa/model/task.py
@@ -32,7 +32,6 @@ class Task(db.Model, DomainObject):
     '''
     __tablename__ = 'task'
 
-
     #: Task.ID
     id = Column(Integer, primary_key=True)
     #: UTC timestamp when the task was created.
@@ -54,7 +53,6 @@ class Task(db.Model, DomainObject):
     fav_user_ids = Column(MutableList.as_mutable(ARRAY(Integer)))
 
     task_runs = relationship(TaskRun, cascade='all, delete, delete-orphan', backref='task')
-
 
     def pct_status(self):
         """Returns the percentage of Tasks that are completed"""


### PR DESCRIPTION
In order to enable parameter user_ip from pybossa-client it shouldn't be overriden by:
```
taskrun.user_ip = request.remote_addr
```