### PR TITLE
enable user_ip via API

### DIFF
--- a/pybossa/api/__init__.py
+++ b/pybossa/api/__init__.py
@@ -93,6 +93,7 @@ def register_api(view, endpoint, url, pk='id', pk_type='int'):
                            view_func=view_func,
                            methods=['GET', 'PUT', 'DELETE', 'OPTIONS'])
 
+
 register_api(ProjectAPI, 'api_project', '/project', pk='oid', pk_type='int')
 register_api(ProjectStatsAPI, 'api_projectstats', '/projectstats', pk='oid', pk_type='int')
 register_api(CategoryAPI, 'api_category', '/category', pk='oid', pk_type='int')

--- a/pybossa/api/task_run.py
+++ b/pybossa/api/task_run.py
@@ -52,7 +52,6 @@ class TaskRunAPI(APIBase):
         self._add_user_info(taskrun)
         self._add_created_timestamp(taskrun, task, guard)
 
-
     def _forbidden_attributes(self, data):
         for key in data.keys():
             if key in self.reserved_keys:
@@ -61,7 +60,7 @@ class TaskRunAPI(APIBase):
     def _validate_project_and_task(self, taskrun, task):
         if task is None:  # pragma: no cover
             raise Forbidden('Invalid task_id')
-        if (task.project_id != taskrun.project_id):
+        if task.project_id != taskrun.project_id:
             raise Forbidden('Invalid project_id')
         if taskrun.external_uid:
             resp = jwt_authorize_project(task.project,
@@ -75,12 +74,13 @@ class TaskRunAPI(APIBase):
             raise Forbidden('You must request a task first!')
 
     def _add_user_info(self, taskrun):
-        if current_user.is_anonymous() and taskrun.user_ip is None:
-            taskrun.user_ip = request.remote_addr
-            if taskrun.user_ip is None:
-                taskrun.user_ip = '127.0.0.1'
-        else:
-            taskrun.user_id = current_user.id
+        if not taskrun.user_ip and not taskrun.user_id:
+            if current_user.is_anonymous():
+                taskrun.user_ip = request.remote_addr
+                if taskrun.user_ip is None:
+                    taskrun.user_ip = '127.0.0.1'
+            else:
+                taskrun.user_id = current_user.id
 
     def _add_created_timestamp(self, taskrun, task, guard):
         taskrun.created = guard.retrieve_timestamp(task, get_user_id_or_ip())

--- a/pybossa/api/task_run.py
+++ b/pybossa/api/task_run.py
@@ -75,7 +75,7 @@ class TaskRunAPI(APIBase):
             raise Forbidden('You must request a task first!')
 
     def _add_user_info(self, taskrun):
-        if current_user.is_anonymous():
+        if current_user.is_anonymous() and taskrun.user_ip is None:
             taskrun.user_ip = request.remote_addr
             if taskrun.user_ip is None:
                 taskrun.user_ip = '127.0.0.1'

--- a/pybossa/model/task.py
+++ b/pybossa/model/task.py
@@ -32,7 +32,6 @@ class Task(db.Model, DomainObject):
     '''
     __tablename__ = 'task'
 
-
     #: Task.ID
     id = Column(Integer, primary_key=True)
     #: UTC timestamp when the task was created.
@@ -54,7 +53,6 @@ class Task(db.Model, DomainObject):
     fav_user_ids = Column(MutableList.as_mutable(ARRAY(Integer)))
 
     task_runs = relationship(TaskRun, cascade='all, delete, delete-orphan', backref='task')
-
 
     def pct_status(self):
         """Returns the percentage of Tasks that are completed"""

--- a/pybossa/model/task_run.py
+++ b/pybossa/model/task_run.py
@@ -24,7 +24,6 @@ from pybossa.core import db
 from pybossa.model import DomainObject, make_timestamp
 
 
-
 class TaskRun(db.Model, DomainObject):
     '''A run of a given task by a specific user.
     '''
@@ -51,7 +50,7 @@ class TaskRun(db.Model, DomainObject):
     external_uid = Column(Text)
     #: Value of the answer.
     info = Column(JSON)
-    '''General writable field that should be used by clients to record results\
+    '''General writable field that should be used by clients to record results
     of a TaskRun. Usually a template for this will be provided by Task
     For example::
         result: {


### PR DESCRIPTION
Preventing overriding user_ip, if given via API, in line:
```
taskrun.user_ip = request.remote_addr
```