### PR TITLE
Add Windows fix to Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,7 +21,10 @@ $ansible_local_provisioning_script = <<SCRIPT
 export DEBIAN_FRONTEND=noninteractive
 export PYTHONUNBUFFERED=1
 echo PyBossa provisioning with Ansible...
-ansible-playbook /vagrant/provisioning/playbook.yml -i /vagrant/provisioning/ansible_hosts -c local
+cp /vagrant/provisioning/ansible_hosts /home/vagrant/
+chmod 666 /home/vagrant/ansible_hosts
+echo Running playbook...
+ansible-playbook /vagrant/provisioning/playbook.yml -i /home/vagrant/ansible_hosts -c local
 SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|


### PR DESCRIPTION
Update the Vagrantfile to avoid ERROR: problem running ansible_hosts --list ([Errno 8] Exec format error), which happens on Windows as the hosts file gets marked as executable when /vagrant/provisioning/hosts is used.