### PR TITLE
Check info is not null in handle_info_json

### DIFF
--- a/pybossa/repositories/__init__.py
+++ b/pybossa/repositories/__init__.py
@@ -88,7 +88,7 @@ class Repository(object):
         clauses = []
         headlines = []
         order_by_ranks = []
-        if '::' in info:
+        if info and '::' in info:
             pairs = info.split('|')
             for pair in pairs:
                 if pair != '':


### PR DESCRIPTION
As results can be created with a `null` info field I think we should add a check here, otherwise attempting to search this info field can throw errors.