### PR TITLE
Api search

### DIFF
--- a/pybossa/repositories/__init__.py
+++ b/pybossa/repositories/__init__.py
@@ -107,8 +107,6 @@ class Repository(object):
                         clauses.append(_entity_descriptor(model,
                                                           'info')[k].astext == v)
         else:
-            print type(info)
-            print info
             if type(info) == dict:
                 clauses.append(_entity_descriptor(model, 'info') == info)
             if type(info) == str or type(info) == unicode:

--- a/pybossa/repositories/__init__.py
+++ b/pybossa/repositories/__init__.py
@@ -88,29 +88,6 @@ class Repository(object):
         clauses = []
         headlines = []
         order_by_ranks = []
-        # if '->>' in info:
-        #     pairs = info.split('|')
-        #     for pair in pairs:
-        #         if pair != '':
-        #             k, v = pair.split("::")
-        #             if fulltextsearch == '1':
-        #                 first_key, second_key = k.split('->>')
-        #                 print first_key, second_key
-        #                 vector = _entity_descriptor(model,
-        #                                             'info')[(first_key,
-        #                                                      second_key)].astext
-        #                 # vector = _entity_descriptor(model, 'info')[k]
-        #                 clause = func.to_tsvector(vector).match(v)
-        #                 clauses.append(clause)
-        #                 if len(headlines) == 0:
-        #                     headline = func.ts_headline(self.language, vector, func.to_tsquery(v))
-        #                     headlines.append(headline)
-        #                     order = func.ts_rank_cd(func.to_tsvector(vector), func.to_tsquery(v), 4).label('rank')
-        #                     order_by_ranks.append(order)
-        #             else:
-        #                 clauses.append(_entity_descriptor(model,
-        #                                                   'info')[k].astext == v)
-        #     return clauses, headlines, order_by_ranks
 
         if info and '::' in info:
             pairs = info.split('|')
@@ -130,11 +107,15 @@ class Repository(object):
                         clauses.append(_entity_descriptor(model,
                                                           'info')[k].astext == v)
         else:
+            print type(info)
+            print info
             if type(info) == dict:
                 clauses.append(_entity_descriptor(model, 'info') == info)
             if type(info) == str or type(info) == unicode:
                 try:
                     info = json.loads(info)
+                    if type(info) == int or type(info) == float:
+                        info = '"%s"' % info
                 except ValueError:
                     info = '"%s"' % info
                 clauses.append(_entity_descriptor(model,

--- a/test/test_repository/test_task_repository.py
+++ b/test/test_repository/test_task_repository.py
@@ -76,6 +76,22 @@ class TestTaskRepositoryForTaskQueries(Test):
         assert res[0].info == 'answer', res[0]
 
     @with_context
+    def test_handle_info_json_integer(self):
+        """Test handle info in JSON as integer text works."""
+        TaskFactory.create(info=95)
+        res = self.task_repo.filter_tasks_by(info='"95"')
+        assert len(res) == 1
+        assert res[0].info == 95, res[0]
+
+    @with_context
+    def test_handle_info_json_float(self):
+        """Test handle info in JSON as floattext works."""
+        TaskFactory.create(info=9.5)
+        res = self.task_repo.filter_tasks_by(info='"9.5"')
+        assert len(res) == 1
+        assert res[0].info == 9.5, res[0]
+
+    @with_context
     def test_handle_info_json(self):
         """Test handle info in JSON works."""
         TaskFactory.create(info={'foo': 'bar'})

--- a/test/test_repository/test_task_repository.py
+++ b/test/test_repository/test_task_repository.py
@@ -86,10 +86,10 @@ class TestTaskRepositoryForTaskQueries(Test):
     @with_context
     def test_handle_info_json_float(self):
         """Test handle info in JSON as floattext works."""
-        TaskFactory.create(info=9.5)
-        res = self.task_repo.filter_tasks_by(info='"9.5"')
+        TaskFactory.create(info='9.5')
+        res = self.task_repo.filter_tasks_by(info='9.5')
         assert len(res) == 1
-        assert res[0].info == 9.5, res[0]
+        assert res[0].info == '9.5', res[0]
 
     @with_context
     def test_handle_info_json(self):


### PR DESCRIPTION
This new PR will allow using the @> Postgresql operator within the info fields. Basically, you will be able to get all the domain objects that follow a path like this:

```
http://localhost:5001/api/taskrun?info={"answer":[{"relevant":false}]}
```
NOTE: you might need to escape your URL if you are using it directly from JS, otherwise chrome does the work for you.