### PR TITLE
redis connection from settings test

### DIFF
--- a/test/test_contributions_guard.py
+++ b/test/test_contributions_guard.py
@@ -16,15 +16,19 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with PYBOSSA.  If not, see <http://www.gnu.org/licenses/>.
 
-from redis import StrictRedis
 from pybossa.contributions_guard import ContributionsGuard
 from pybossa.model.task import Task
 from mock import patch
+import settings_test
+from redis.sentinel import Sentinel
+
 
 class TestContributionsGuard(object):
 
     def setUp(self):
-        self.connection = StrictRedis()
+        sentinel = Sentinel(settings_test.REDIS_SENTINEL)
+        db = getattr(settings_test, 'REDIS_DB', 0)
+        self.connection = sentinel.master_for('mymaster', db=db)
         self.connection.flushall()
         self.guard = ContributionsGuard(self.connection)
         self.anon_user = {'user_id': None, 'user_ip': '127.0.0.1'}

--- a/test/test_jobs/test_maintenance.py
+++ b/test/test_jobs/test_maintenance.py
@@ -16,19 +16,17 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with PYBOSSA.  If not, see <http://www.gnu.org/licenses/>.
 
-import json
 from pybossa.core import sentinel
 from pybossa.jobs import check_failed, get_maintenance_jobs
 from default import Test, with_context, FakeResponse, db
-from redis import StrictRedis
-from mock import patch, MagicMock, call
+from mock import patch, MagicMock
 
 
 class TestMaintenance(Test):
 
     def setUp(self):
         super(TestMaintenance, self).setUp()
-        self.connection = StrictRedis()
+        self.connection = sentinel.master
         self.connection.flushall()
 
     @with_context

--- a/test/test_jobs/test_news.py
+++ b/test/test_jobs/test_news.py
@@ -16,13 +16,11 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with PYBOSSA.  If not, see <http://www.gnu.org/licenses/>.
 
-import json
 from pybossa.core import sentinel
 from pybossa.jobs import news
 from pybossa.news import get_news
 from default import Test, with_context, FakeResponse, db
 from factories import UserFactory
-from redis import StrictRedis
 from mock import patch, MagicMock, call
 
 

--- a/test/test_jobs/test_webhooks.py
+++ b/test/test_jobs/test_webhooks.py
@@ -24,10 +24,10 @@ from factories import ProjectFactory
 from factories import TaskFactory
 from factories import TaskRunFactory
 from factories import WebhookFactory
-from redis import StrictRedis
 from mock import patch, MagicMock
 from datetime import datetime
 from pybossa.repositories import ResultRepository
+from pybossa.core import sentinel
 
 queue = MagicMock()
 queue.enqueue.return_value = True
@@ -40,12 +40,11 @@ class TestWebHooks(Test):
     @with_context
     def setUp(self):
         super(TestWebHooks, self).setUp()
-        self.connection = StrictRedis()
+        self.connection = sentinel.master
         self.connection.flushall()
         self.project = ProjectFactory.create()
         self.webhook_payload = dict(project_id=self.project.id,
                                     project_short_name=self.project.short_name)
-
 
     @with_context
     @patch('pybossa.jobs.requests.post')
@@ -105,7 +104,6 @@ class TestWebHooks(Test):
         assert queue.enqueue.called is False, queue.enqueue.called
         assert task.state != 'completed'
         queue.reset_mock()
-
 
     @with_context
     @patch('pybossa.model.event_listeners.webhook_queue', new=queue)

--- a/test/test_news.py
+++ b/test/test_news.py
@@ -19,7 +19,6 @@ from default import Test, with_context
 from pybossa.news import get_news, notify_news_admins
 from pybossa.core import sentinel
 from factories import UserFactory
-from redis import StrictRedis
 try:
     import cPickle as pickle
 except ImportError:  # pragma: no cover
@@ -27,11 +26,12 @@ except ImportError:  # pragma: no cover
 
 myset = 'scifabricnews'
 
+
 class TestNews(Test):
 
     def setUp(self):
         super(TestNews, self).setUp()
-        self.connection = StrictRedis()
+        self.connection = sentinel.master
         self.connection.flushall()
 
     news = dict(updated='2015-01-01')


### PR DESCRIPTION
Hello, I noticed that some tests fail if the default value for `REDIS_SENTINEL` in settings_test is changed and sentinel is not running on localhost. With these changes the address of sentinel is taken from settings_test.