### PR TITLE
user pref and metadata for user accounts

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "pybossa/themes/default"]
 	path = pybossa/themes/default
-	url = https://github.com/PyBossa/pybossa-default-theme.git
+	url = https://github.com/Pybossa/pybossa-default-theme.git

--- a/alembic/versions/d317dc38cf39_add_user_pref_to_user.py
+++ b/alembic/versions/d317dc38cf39_add_user_pref_to_user.py
@@ -1,0 +1,22 @@
+"""add user_pref to user
+
+Revision ID: d317dc38cf39
+Revises: fa8cf884aa8e
+Create Date: 2018-02-13 22:24:18.363617
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'd317dc38cf39'
+down_revision = 'fa8cf884aa8e'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+def upgrade():
+    op.add_column('user', sa.Column('user_pref', JSONB))
+
+
+def downgrade():
+    op.drop_column('user', 'user_pref')

--- a/pybossa/cache/users.py
+++ b/pybossa/cache/users.py
@@ -249,14 +249,17 @@ def get_users_page(page, per_page=24):
         accounts.append(tmp)
     return accounts
 
+
 def delete_user_summary_id(oid):
     """Delete from cache the user summary."""
     user = db.session.query(User).get(oid)
     delete_memoized(get_user_summary, user.name)
 
+
 def delete_user_summary(name):
     """Delete from cache the user summary."""
     delete_memoized(get_user_summary, name)
+
 
 @memoize(timeout=timeouts.get('APP_TIMEOUT'))
 def get_project_report_userdata(project_id):
@@ -286,3 +289,20 @@ def get_project_report_userdata(project_id):
          round(row.avg_time_per_task.total_seconds() / 60, 2)]
          for row in results]
     return users_report
+
+
+@memoize(timeout=timeouts.get('APP_TIMEOUT'))
+def get_user_pref_metadata(name):
+    sql = text("""
+    SELECT info->'metadata', user_pref FROM public.user WHERE name=:name;
+    """)
+
+    cursor = session.execute(sql, dict(name=name))
+    row = cursor.fetchone()
+    upref_mdata = row[0] or {}
+    upref_mdata.update(row[1] or {})
+    return upref_mdata
+
+
+def delete_user_pref_metadata(name):
+    delete_memoized(get_user_pref_metadata, name)

--- a/pybossa/core.py
+++ b/pybossa/core.py
@@ -78,6 +78,7 @@ def create_app(run_as_server=True):
     plugin_manager.init_app(app)
     plugin_manager.install_plugins()
     import pybossa.model.event_listeners
+    setup_upref_mdata(app)
     return app
 
 
@@ -91,6 +92,12 @@ def configure_app(app):
         config_path = os.path.join(os.path.dirname(here), 'settings_local.py')
         if os.path.exists(config_path):  # pragma: no cover
             app.config.from_pyfile(config_path)
+    else:
+        config_path = os.path.abspath(os.environ.get('PYBOSSA_SETTINGS'))
+
+    config_upref_mdata = os.path.join(os.path.dirname(config_path), 'settings_upref_mdata.py')
+    app.config.upref_mdata = True if os.path.exists(config_upref_mdata) else False
+
     # Override DB in case of testing
     if app.config.get('SQLALCHEMY_DATABASE_TEST_URI'):
         app.config['SQLALCHEMY_DATABASE_URI'] = \
@@ -706,6 +713,7 @@ def setup_strong_password(app):
     global enable_strong_password
     enable_strong_password = app.config.get('ENABLE_STRONG_PASSWORD')
 
+
 def setup_ldap(app):
     if app.config.get('LDAP_HOST'):
         ldap.init_app(app)
@@ -713,3 +721,16 @@ def setup_ldap(app):
 def setup_profiler(app):
     if app.config.get('FLASK_PROFILER'):
         flask_profiler.init_app(app)
+
+def setup_upref_mdata(app):
+    """Setup user preference and metadata choices for user accounts"""
+    global upref_mdata_choices
+    upref_mdata_choices = dict(languages=[], locations=[],
+                                timezones=[], user_types=[])
+    if app.config.upref_mdata:
+        from settings_upref_mdata import (upref_languages, upref_locations,
+                mdata_timezones, mdata_user_types)
+        upref_mdata_choices['languages'] = upref_languages()
+        upref_mdata_choices['locations'] = upref_locations()
+        upref_mdata_choices['timezones'] = mdata_timezones()
+        upref_mdata_choices['user_types'] = mdata_user_types()

--- a/pybossa/forms/fields/__init__.py
+++ b/pybossa/forms/fields/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf8 -*-
+# This file is part of PyBossa.
+#
+# Copyright (C) 2018 SciFabric LTD.
+#
+# PyBossa is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PyBossa is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with PyBossa.  If not, see <http://www.gnu.org/licenses/>.

--- a/pybossa/forms/fields/time_field.py
+++ b/pybossa/forms/fields/time_field.py
@@ -1,0 +1,54 @@
+# -*- coding: utf8 -*-
+# This file is part of PyBossa.
+#
+# Copyright (C) 2018 SciFabric LTD.
+#
+# PyBossa is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PyBossa is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with PyBossa.  If not, see <http://www.gnu.org/licenses/>.
+
+
+
+from __future__ import absolute_import
+
+import datetime
+import time
+
+from wtforms.fields import Field
+
+from wtforms_components.widgets import TimeInput
+
+class TimeField(Field):
+    widget = TimeInput()
+    error_msg = 'Please fill out field'
+
+    def __init__(self, label=None, validators=None, format="%H:%M", **kwargs):
+        super(TimeField, self).__init__(label, validators, **kwargs)
+        self.format = format
+
+    def _value(self):
+        if self.raw_data:
+            return ' '.join(self.raw_data)
+        elif self.data is not None:
+            return self.data
+        else:
+            return ''
+
+    def process_formdata(self, valuelist):
+        if valuelist:
+            time_str = ' '.join(valuelist)
+            try:
+                self.data = datetime.time(*time.strptime(time_str, self.format)[3:6])
+                self.data = self.data.strftime("%H:%M")
+
+            except ValueError:
+                self.data = None

--- a/pybossa/forms/validator.py
+++ b/pybossa/forms/validator.py
@@ -163,3 +163,17 @@ class CheckPasswordStrength(object):
             return 'Password must contain at least {} character.'\
                 .format(', '.join(message))
         return None
+
+
+class TimeFieldsValidator(object):
+    def __init__(self, fields, message=None):
+        if not message:
+            message = "Fill out empty field(s)"
+        self.message = message
+        self.fields = fields
+
+    def __call__(self, form, field):
+        values = [form.data[fld] for fld in self.fields]
+        values.append(field.data)
+        if any(values) and not all(values):
+            raise ValidationError(self.message)

--- a/pybossa/model/user.py
+++ b/pybossa/model/user.py
@@ -64,6 +64,7 @@ class User(db.Model, DomainObject, UserMixin):
     subscribed = Column(Boolean, default=True)
     consent = Column(Boolean, default=False)
     info = Column(MutableDict.as_mutable(JSONB), default=dict())
+    user_pref = Column(JSONB)
 
     ## Relationships
     task_runs = relationship(TaskRun, backref='user')

--- a/pybossa/util.py
+++ b/pybossa/util.py
@@ -38,6 +38,7 @@ import simplejson
 import time
 from flask.ext.babel import lazy_gettext
 import re
+import pycountry
 
 
 def last_flashed_message():

--- a/settings_upref_mdata.py.tmpl
+++ b/settings_upref_mdata.py.tmpl
@@ -1,0 +1,110 @@
+import pycountry
+
+def upref_languages():
+    langs = [("Afrikaans", "Afrikaans"),
+        ("Albanian", "Albanian"),
+        ("Arabic", "Arabic"),
+        ("Armenian", "Armenian"),
+        ("Bengali", "Bengali"),
+        ("Bosnian", "Bosnian"),
+        ("Bulgarian", "Bulgarian"),
+        ("Catalan", "Catalan"),
+        ("Croatian", "Croatian"),
+        ("Czech", "Czech"),
+        ("Danish", "Danish"),
+        ("Dutch", "Dutch"),
+        ("English", "English"),
+        ("Estonian", "Estonian"),
+        ("Filipino", "Filipino"),
+        ("Finnish", "Finnish"),
+        ("French", "French"),
+        ("German", "German"),
+        ("Greek", "Greek"),
+        ("Hebrew", "Hebrew"),
+        ("Hindi", "Hindi"),
+        ("Hungarian", "Hungarian"),
+        ("Icelandic", "Icelandic"),
+        ("Indonesian", "Indonesian"),
+        ("Italian", "Italian"),
+        ("Japanese", "Japanese"),
+        ("Korean", "Korean"),
+        ("Latvian", "Latvian"),
+        ("Lithuanian", "Lithuanian"),
+        ("Luxembourgish", "Luxembourgish"),
+        ("Macedonian", "Macedonian"),
+        ("Malay", "Malay"),
+        ("Maltese", "Maltese"),
+        ("Mongolian", "Mongolian"),
+        ("Norwegian", "Norwegian"),
+        ("Polish", "Polish"),
+        ("Portuguese", "Portuguese"),
+        ("Punjabi", "Punjabi"),
+        ("Romanian", "Romanian"),
+        ("Russian", "Russian"),
+        ("Samoan", "Samoan"),
+        ("Serbian", "Serbian"),
+        ("Simplified Chinese", "Simplified Chinese"),
+        ("Slovak", "Slovak"),
+        ("Slovenian", "Slovenian"),
+        ("Spanish", "Spanish"),
+        ("Swedish", "Swedish"),
+        ("Tamil", "Tamil"),
+        ("Thai", "Thai"),
+        ("Traditional Chinese", "Traditional Chinese"),
+        ("Turkish", "Turkish"),
+        ("Ukrainian", "Ukrainian"),
+        ("Vietnamese", "Vietnamese"),
+        ("Welsh", "Welsh")]
+    return langs
+
+
+def upref_locations():
+    cts = []
+    for ct in pycountry.countries:
+        name = ct.name.encode('ascii', 'ignore').replace("'", "")
+        cts.append((name, name))
+    return sorted(cts)
+
+
+def mdata_user_types():
+    types = [("", ""),
+        ("Researcher", "Researcher"),
+        ("Analyst", "Analyst"),
+        ("Curator", "Curator")]
+    return types
+
+
+def mdata_timezones():
+    tz = [("", ""), ("ACT", "Australia Central Time"),
+        ("AET", "Australia Eastern Time"),
+        ("AGT", "Argentina Standard Time"),
+        ("ART", "(Arabic) Egypt Standard Time"),
+        ("AST", "Alaska Standard Time"),
+        ("BET", "Brazil Eastern Time"),
+        ("BST", "Bangladesh Standard Time"),
+        ("CAT", "Central African Time"),
+        ("CNT", "Canada Newfoundland Time"),
+        ("CST", "Central Standard Time"),
+        ("CTT", "China Taiwan Time"),
+        ("EAT", "Eastern African Time"),
+        ("ECT", "European Central Time"),
+        ("EET", "Eastern European Time"),
+        ("EST", "Eastern Standard Time"),
+        ("GMT", "Greenwich Mean Time"),
+        ("HST", "Hawaii Standard Time"),
+        ("IET", "Indiana Eastern Standard Time"),
+        ("IST", "India Standard Time"),
+        ("JST", "Japan Standard Time"),
+        ("MET", "Middle East Time"),
+        ("MIT", "Midway Islands Time"),
+        ("MST", "Mountain Standard Time"),
+        ("NET", "Near East Time"),
+        ("NST", "New Zealand Standard Time"),
+        ("PLT", "Pakistan Lahore Time"),
+        ("PNT", "Phoenix Standard Time"),
+        ("PRT", "Puerto Rick and US Virgin Islands Time"),
+        ("PST", "Pacific Standard Time"),
+        ("SST", "Solomon Standard Time"),
+        ("UTC", "Universal Coordinated Time"),
+        ("VST", "Vietnam Standard Time")]
+    return tz

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,8 @@ requirements = [
     "otpauth>=1.0.1, <1.0.2",
     "Flask-SimpleLDAP >=1.1.2, <1.1.3",
     "flask_profiler >= 1.6, <1.6.1",
+    "pycountry",
+    "wtforms-components>=0.10.3, <0.10.4",
 ]
 
 setup(


### PR DESCRIPTION
Hello,

We just added a feature to set user preferences for their preferred languages/locations and metadata such as users work hours, expertise about a user on account filing form.  The user preferences and metadata would be available and modified from account profile page.  https://github.com/Scifabric/docs.pybossa.com/pull/24 has documentation on this feature along with screenshots. In future, this could be useful for building a new scheduler that can assign tasks to a user based on his/her preferences set.
  