### PR TITLE
Add IIIF importer

### DIFF
--- a/pybossa/forms/forms.py
+++ b/pybossa/forms/forms.py
@@ -288,18 +288,34 @@ class BulkTaskLocalCSVImportForm(Form):
         return {'type': 'localCSV', 'csv_filename': None}
 
 
+class BulkTaskIIIFImportForm(Form):
+    form_name = TextField(label=None, widget=HiddenInput(), default='iiif')
+    msg_required = lazy_gettext("You must provide a URL")
+    msg_url = lazy_gettext("Oops! That's not a valid URL. "
+                           "You must provide a valid URL")
+    manifest_uri = TextField(lazy_gettext('URL'),
+                             [validators.Required(message=msg_required),
+                             validators.URL(message=msg_url)])
+
+    def get_import_data(self):
+        return {'type': 'iiif', 'manifest_uri': self.manifest_uri.data}
+
+
 class GenericBulkTaskImportForm(object):
     """Callable class that will return, when called, the appropriate form
     instance"""
-    _forms = { 'csv': BulkTaskCSVImportForm,
-              'gdocs': BulkTaskGDImportForm,
-              'epicollect': BulkTaskEpiCollectPlusImportForm,
-              'flickr': BulkTaskFlickrImportForm,
-              'dropbox': BulkTaskDropboxImportForm,
-              'twitter': BulkTaskTwitterImportForm,
-              's3': BulkTaskS3ImportForm,
-              'youtube': BulkTaskYoutubeImportForm,
-              'localCSV': BulkTaskLocalCSVImportForm }
+    _forms = {
+        'csv': BulkTaskCSVImportForm,
+        'gdocs': BulkTaskGDImportForm,
+        'epicollect': BulkTaskEpiCollectPlusImportForm,
+        'flickr': BulkTaskFlickrImportForm,
+        'dropbox': BulkTaskDropboxImportForm,
+        'twitter': BulkTaskTwitterImportForm,
+        's3': BulkTaskS3ImportForm,
+        'youtube': BulkTaskYoutubeImportForm,
+        'localCSV': BulkTaskLocalCSVImportForm,
+        'iiif': BulkTaskIIIFImportForm
+    }
 
     def __call__(self, form_name, *form_args, **form_kwargs):
         if form_name is None:

--- a/pybossa/importers/iiif.py
+++ b/pybossa/importers/iiif.py
@@ -1,0 +1,87 @@
+# -*- coding: utf8 -*-
+# This file is part of PYBOSSA.
+#
+# Copyright (C) 2018 Scifabric LTD.
+#
+# PYBOSSA is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PYBOSSA is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with PYBOSSA.  If not, see <http://www.gnu.org/licenses/>.
+
+import json
+import requests
+
+from .base import BulkTaskImport, BulkImportException
+
+
+class BulkTaskIIIFImporter(BulkTaskImport):
+    """Class to import tasks from IIIF manifests."""
+
+    importer_id = "iiif"
+
+    def __init__(self, manifest_uri):
+        """Init method."""
+        self.manifest_uri = manifest_uri
+
+    def tasks(self):
+        """Get tasks."""
+        return self._generate_tasks()
+
+    def count_tasks(self):
+        """Count number of tasks."""
+        return len(self.tasks())
+
+    def _generate_tasks(self):
+        """Generate the tasks."""
+        manifest = self._get_validated_manifest(self.manifest_uri)
+        task_data = self._get_task_data(manifest)
+        return [dict(info=data) for data in task_data]
+
+    def _get_task_data(self, manifest):
+        """Return the task data generated from a manifest."""
+        manifest_uri = manifest['@id']
+        canvases = manifest['sequences'][0]['canvases']
+        images = [c['images'][0]['resource']['service']['@id']
+                  for c in canvases]
+
+        data = []
+        for i, img in enumerate(images):
+            row = {
+                'tileSource': '{}/info.json'.format(img),
+                'target': canvases[i]['@id'],
+                'manifest': manifest_uri,
+                'link': self._get_link(manifest_uri, i),
+                'url': '{}/full/max/0/default.jpg'.format(img),
+                'url_m': '{}/full/240,/0/default.jpg'.format(img),
+                'url_b': '{}/full/1024,/0/default.jpg'.format(img)
+            }
+            data.append(row)
+        return data
+
+    def _get_link(self, manifest_uri, canvas_index):
+        """Return a Universal Viewer URL for sharing."""
+        base = 'http://universalviewer.io/uv.html'
+        query = '?manifest={}#?cv={}'.format(manifest_uri, canvas_index)
+        return base + query
+
+    def _get_validated_manifest(self, manifest_uri):
+        """Return a validated manifest."""
+        url = 'http://iiif.io/api/presentation/validator/service/validate'
+        payload = dict(format='json', url=manifest_uri)
+        response = requests.get(url, params=payload)
+        json_response = json.loads(response.text)
+        valid = (response.status_code == 200 and json_response.get('okay'))
+
+        if not valid:
+            default_err = "Oops! That doesn't look like a valid IIIF manifest."
+            raise BulkImportException(json_response.get('error', default_err))
+
+        return json_response['received']

--- a/pybossa/importers/importer.py
+++ b/pybossa/importers/importer.py
@@ -23,6 +23,7 @@ from .flickr import BulkTaskFlickrImport
 from .twitterapi import BulkTaskTwitterImport
 from .youtubeapi import BulkTaskYoutubeImport
 from .epicollect import BulkTaskEpiCollectPlusImport
+from .iiif import BulkTaskIIIFImporter
 from .s3 import BulkTaskS3Import
 
 class Importer(object):
@@ -35,7 +36,8 @@ class Importer(object):
                                gdocs=BulkTaskGDImport,
                                epicollect=BulkTaskEpiCollectPlusImport,
                                s3=BulkTaskS3Import,
-                               localCSV=BulkTaskLocalCSVImport)
+                               localCSV=BulkTaskLocalCSVImport,
+                               iiif=BulkTaskIIIFImporter)
         self._importer_constructor_params = dict()
 
     def register_flickr_importer(self, flickr_params):

--- a/test/test_importers/__init__.py
+++ b/test/test_importers/__init__.py
@@ -111,7 +111,8 @@ class TestImporterPublicMethods(Test):
     @with_context
     def test_get_all_importer_names_returns_default_importer_names(self, create):
         importers = self.importer.get_all_importer_names()
-        expected_importers = ['csv', 'gdocs', 'epicollect', 's3', 'localCSV']
+        expected_importers = ['csv', 'gdocs', 'epicollect', 's3', 'localCSV',
+                              'iiif']
 
         assert set(importers) == set(expected_importers)
 
@@ -134,7 +135,7 @@ class TestImporterPublicMethods(Test):
     @with_context
     def test_get_autoimporter_names_returns_default_autoimporter_names(self, create):
         importers = self.importer.get_autoimporter_names()
-        expected_importers = ['csv', 'gdocs', 'epicollect', 'localCSV']
+        expected_importers = ['csv', 'gdocs', 'epicollect', 'localCSV', 'iiif']
 
         assert set(importers) == set(expected_importers)
 

--- a/test/test_importers/test_iiif_importer.py
+++ b/test/test_importers/test_iiif_importer.py
@@ -1,0 +1,138 @@
+# -*- coding: utf8 -*-
+# This file is part of PYBOSSA.
+#
+# Copyright (C) 2018 Scifabric LTD.
+#
+# PYBOSSA is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PYBOSSA is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with PYBOSSA.  If not, see <http://www.gnu.org/licenses/>.
+
+import json
+from mock import patch
+from nose.tools import *
+from pybossa.importers import BulkImportException
+from pybossa.importers.iiif import BulkTaskIIIFImporter
+from default import FakeResponse, with_context
+
+@patch('pybossa.importers.iiif.requests')
+class TestBulkTaskIIIFImport(object):
+
+    def setUp(self):
+        self.manifest_uri = 'http://example.org/iiif/book1/manifest'
+        self.canvas_id_base = 'http://example.org/iiif/book1/canvas/p'
+        self.img_id_base = 'http://example.org/images/book1-page'
+        self.importer = BulkTaskIIIFImporter(manifest_uri=self.manifest_uri)
+
+    def create_manifest(self, sequences=1):
+        manifest = {
+            '@id': self.manifest_uri,
+            'sequences': [
+                {
+                    'canvases': []
+                }
+            ]
+        }
+        for i in range(sequences):
+            canvas = {
+                '@id': self.canvas_id_base.format(i),
+                'images': [
+                    {
+                        'resource': {
+                            'service': {
+                                '@id': self.img_id_base.format(i)
+                            }
+                        }
+                    }
+                ]
+            }
+            manifest['sequences'][0]['canvases'].append(canvas)
+        return manifest
+
+    def test_task_count_returns_1_for_valid_manifest(self, requests):
+        headers = {'Content-Type': 'application/json'}
+        wrapper = {
+            'okay': 1,
+            'received': self.create_manifest()
+        }
+        valid_manifest = FakeResponse(text=json.dumps(wrapper),
+                                      status_code=200, headers=headers,
+                                      encoding='utf-8')
+        requests.get.return_value = valid_manifest
+        count = self.importer.count_tasks()
+        assert_equal(count, 1)
+
+    def test_task_count_raises_exception_for_invalid_manifest(self, requests):
+        headers = {'Content-Type': 'application/json'}
+        wrapper = {
+            'okay': 0,
+            'received': 'Something else'
+        }
+        invalid_manifest = FakeResponse(text=json.dumps(wrapper),
+                                        status_code=200, headers=headers,
+                                        encoding='utf-8')
+        requests.get.return_value = invalid_manifest
+        msg = "Oops! That doesn't look like a valid IIIF manifest."
+
+        assert_raises(BulkImportException, self.importer.count_tasks)
+        try:
+            self.importer.count_tasks()
+        except BulkImportException as e:
+            assert e[0] == msg, e
+
+    @with_context
+    def test_get_tasks_raises_exception_for_invalid_manifest(self, requests):
+        headers = {'Content-Type': 'application/json'}
+        wrapper = {
+            'okay': 0,
+            'received': 'Something else'
+        }
+        invalid_manifest = FakeResponse(text=json.dumps(wrapper),
+                                        status_code=200, headers=headers,
+                                        encoding='utf-8')
+        requests.get.return_value = invalid_manifest
+        msg = "Oops! That doesn't look like a valid IIIF manifest."
+
+        assert_raises(BulkImportException, self.importer.count_tasks)
+        try:
+            self.importer.tasks()
+        except BulkImportException as e:
+            assert e[0] == msg, e
+
+    @with_context
+    def test_get_tasks_for_valid_manifest(self, requests):
+        n = 3
+        headers = {'Content-Type': 'application/json'}
+        wrapper = {
+            'okay': 1,
+            'received': self.create_manifest(n)
+        }
+        valid_manifest = FakeResponse(text=json.dumps(wrapper),
+                                      status_code=200, headers=headers,
+                                      encoding='utf-8')
+        requests.get.return_value = valid_manifest
+        tasks = self.importer.tasks()
+
+        assert_equal(len(tasks), n)
+        for i, task in enumerate(tasks):
+            canvas_id = self.canvas_id_base.format(i)
+            img_id = self.img_id_base.format(i)
+            link_query = '?manifest={}#?cv={}'.format(self.manifest_uri, i)
+            link = 'http://universalviewer.io/uv.html' + link_query
+            assert_dict_equal(task['info'], {
+                'manifest': self.manifest_uri,
+                'target': canvas_id,
+                'link': link,
+                'tileSource': '{}/info.json'.format(img_id),
+                'url': '{}/full/max/0/default.jpg'.format(img_id),
+                'url_m': '{}/full/240,/0/default.jpg'.format(img_id),
+                'url_b': '{}/full/1024,/0/default.jpg'.format(img_id)
+            })

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -5335,7 +5335,8 @@ class TestWeb(web.Helper):
                      "projects/tasks/gdocs.html",
                      "projects/tasks/dropbox.html",
                      "projects/tasks/flickr.html",
-                     "projects/tasks/localCSV.html"]
+                     "projects/tasks/localCSV.html",
+                     "projects/tasks/iiif.html"]
         assert data['available_importers'] == importers, data
 
         importers = ['&type=epicollect',
@@ -5346,7 +5347,8 @@ class TestWeb(web.Helper):
                      '&type=gdocs',
                      '&type=dropbox',
                      '&type=flickr',
-                     '&type=localCSV']
+                     '&type=localCSV',
+                     '&type=iiif']
 
         for importer in importers:
             res = self.app_get_json(url + importer)
@@ -5374,6 +5376,8 @@ class TestWeb(web.Helper):
                 assert 'album_id' in data['form'].keys(), data
             if 'localCSV' in importer:
                 assert 'form_name' in data['form'].keys(), data
+            if 'iiif' in importer:
+                assert 'manifest_uri' in data['form'].keys(), data
 
         for importer in importers:
             if 'epicollect' in importer:
@@ -5417,6 +5421,11 @@ class TestWeb(web.Helper):
                 res = self.app_post_json(url + importer, data=data)
                 data = json.loads(res.data)
                 assert data['flash'] == "SUCCESS", data
+            if 'iiif' in importer:
+                data = dict(manifest_uri='http://example.com')
+                res = self.app_post_json(url + importer, data=data)
+                data = json.loads(res.data)
+                assert data['flash'] == "SUCCESS", data
 
 
     @with_context
@@ -5439,7 +5448,8 @@ class TestWeb(web.Helper):
                      "projects/tasks/gdocs.html",
                      "projects/tasks/dropbox.html",
                      "projects/tasks/flickr.html",
-                     "projects/tasks/localCSV.html"]
+                     "projects/tasks/localCSV.html",
+                     "projects/tasks/iiif.html"]
         assert data['available_importers'] == importers, data
 
 
@@ -5529,6 +5539,14 @@ class TestWeb(web.Helper):
         data = res.data.decode('utf-8')
 
         assert "From an Amazon S3 bucket" in data
+        assert 'action="/project/%E2%9C%93project1/tasks/import"' in data
+
+        # IIIF
+        url = "/project/%s/tasks/import?type=iiif" % project.short_name
+        res = self.app.get(url, follow_redirects=True)
+        data = res.data.decode('utf-8')
+
+        assert "From a IIIF manifest" in data
         assert 'action="/project/%E2%9C%93project1/tasks/import"' in data
 
         # Invalid


### PR DESCRIPTION
Here's an importer to generate tasks from [IIIF](http://iiif.io/) manifests. Just pass in the manifest URL and a task will be created for each canvas. Here's an example from the British Library to try it out with:

https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100022589088.0x000002/manifest.json

Will add the docs too.