### PR TITLE
Import all images from all canvases

### DIFF
--- a/pybossa/importers/iiif.py
+++ b/pybossa/importers/iiif.py
@@ -49,21 +49,23 @@ class BulkTaskIIIFImporter(BulkTaskImport):
         """Return the task data generated from a manifest."""
         manifest_uri = manifest['@id']
         canvases = manifest['sequences'][0]['canvases']
-        images = [c['images'][0]['resource']['service']['@id']
-                  for c in canvases]
 
         data = []
-        for i, img in enumerate(images):
-            row = {
-                'tileSource': '{}/info.json'.format(img),
-                'target': canvases[i]['@id'],
-                'manifest': manifest_uri,
-                'link': self._get_link(manifest_uri, i),
-                'url': '{}/full/max/0/default.jpg'.format(img),
-                'url_m': '{}/full/240,/0/default.jpg'.format(img),
-                'url_b': '{}/full/1024,/0/default.jpg'.format(img)
-            }
-            data.append(row)
+        for i, canvas in enumerate(canvases):
+            images = [img['resource']['service']['@id']
+                      for img in canvas['images']]
+
+            for img in images:
+                row = {
+                    'tileSource': '{}/info.json'.format(img),
+                    'target': canvas['@id'],
+                    'manifest': manifest_uri,
+                    'link': self._get_link(manifest_uri, i),
+                    'url': '{}/full/max/0/default.jpg'.format(img),
+                    'url_m': '{}/full/240,/0/default.jpg'.format(img),
+                    'url_b': '{}/full/1024,/0/default.jpg'.format(img)
+                }
+                data.append(row)
         return data
 
     def _get_link(self, manifest_uri, canvas_index):


### PR DESCRIPTION
Within the IIIF API, it occurred to me that, although it wouldn't happen for the majority of collections, it is in fact possible to have multiple images defined for each canvas, where a canvas is a container onto which an image (or multiple images) are painted. This PR ensures that all images for all canvases are imported. In 99% of cases this probably doesn't change anything but I think the option should be built in here, just in case. I'll send a documentation update to make it clearer how the importer works.