### PR TITLE
Added a new line on the documentation

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -171,6 +171,17 @@
         state=present
         insertafter=EOF
         create=yes
+        
+     # activate virtualenv ->line redis-server {{pybossa_path}}/contrib/sentinel.conf --sentinel added
+    - name: virtualenv usage by default on bash login
+      become_user: "{{pybossa_user}}"
+      lineinfile:
+        dest={{vagrant_home}}/.bashrc
+        line="redis-server {{pybossa_path}}/contrib/sentinel.conf --sentinel"
+        owner=vagrant
+        state=present
+        insertafter=EOF
+        create=yes     
 
     - name: go to /vagrant directory on bash login
       lineinfile:


### PR DESCRIPTION
A missing command  " redis-server contrib/sentinel.conf --sentinel " added for the virtual machine restart.