### PR TITLE
Add CRYPTOPAN_KEY to default settings

### DIFF
--- a/pybossa/default_settings.py
+++ b/pybossa/default_settings.py
@@ -152,3 +152,6 @@ UNPUBLISH_PROJECTS = True
 
 # TTL for ZIP files of personal data
 TTL_ZIP_SEC_FILES = 3
+
+# Default cryptopan key
+CRYPTOPAN_KEY = '32-char-str-for-AES-key-and-pad.'


### PR DESCRIPTION
Obviously this should be changed in the local settings but adding a default means that at least it won't fail and cause confusion for people that already have a VM setup (and their settings_local.py file already created).

Closes #1841