### PR TITLE
Fix delete for when no mailchimp key.

### DIFF
--- a/pybossa/exporter/json_export.py
+++ b/pybossa/exporter/json_export.py
@@ -46,7 +46,6 @@ class JsonExporter(Exporter):
 
     def _make_zip(self, project, ty, name=None, data=None, user_id=None,
                   zipname=None):
-        print data
         if data:
             return self.handle_zip(name, data, ty,
                                    user_id, project,

--- a/pybossa/jobs.py
+++ b/pybossa/jobs.py
@@ -782,13 +782,15 @@ def delete_account(user_id, **kwargs):
     newsletter.init_app(current_app)
     user = user_repo.get(user_id)
     email = user.email_addr
-    mailchimp_deleted = newsletter.delete_user(email)
     brand = current_app.config.get('BRAND')
     user_repo.delete(user)
     subject = '[%s]: Your account has been deleted' % brand
+    mailchimp_deleted = True
     body = """Hi,\n Your account and personal data has been deleted from the %s.""" % brand
-    if not mailchimp_deleted:
-        body += '\nWe could not delete your Mailchimp account, please contact us to fix this issue.'
+    if current_app.config.get('MAILCHIMP_API_KEY'):
+        mailchimp_deleted = newsletter.delete_user(email)
+        if not mailchimp_deleted:
+            body += '\nWe could not delete your Mailchimp account, please contact us to fix this issue.'
     if current_app.config.get('DISQUS_SECRET_KEY'):
         body += '\nDisqus does not provide an API method to delete your account. You will have to do it by hand yourself in the disqus.com site.'
     recipients = [email]

--- a/pybossa/jobs.py
+++ b/pybossa/jobs.py
@@ -812,21 +812,29 @@ def export_userdata(user_id, **kwargs):
     taskruns_data = [tr.dictize() for tr in taskruns]
     pdf = json_exporter._make_zip(None, '', 'personal_data', user_data, user_id,
                                   'personal_data.zip')
-    upf = json_exporter._make_zip(None, '', 'user_projects', projects_data, user_id,
-                                  'user_projects.zip')
-    ucf = json_exporter._make_zip(None, '', 'user_contributions', taskruns_data, user_id,
-                                  'user_contributions.zip')
+    upf = None
+    if len(projects_data) > 0:
+        upf = json_exporter._make_zip(None, '', 'user_projects', projects_data, user_id,
+                                      'user_projects.zip')
+    ucf = None
+    if len(taskruns_data) > 0:
+        ucf = json_exporter._make_zip(None, '', 'user_contributions', taskruns_data, user_id,
+                                      'user_contributions.zip')
     upload_method = current_app.config.get('UPLOAD_METHOD')
     if upload_method == 'local':
         upload_method = 'uploads.uploaded_file'
 
     personal_data_link = url_for(upload_method,
                                  filename="user_%s/%s" % (user_id, pdf))
-    personal_projects_link = url_for(upload_method,
-                                    filename="user_%s/%s" % (user_id,
+    personal_projects_link = None
+    if upf:
+        personal_projects_link = url_for(upload_method,
+                                         filename="user_%s/%s" % (user_id,
                                                              upf))
-    personal_contributions_link = url_for(upload_method,
-                                          filename="user_%s/%s" % (user_id,
+    personal_contributions_link = None
+    if ucf:
+        personal_contributions_link = url_for(upload_method,
+                                              filename="user_%s/%s" % (user_id,
                                                                    ucf))
 
     body = render_template('/account/email/exportdata.md',

--- a/pybossa/newsletter/__init__.py
+++ b/pybossa/newsletter/__init__.py
@@ -36,10 +36,11 @@ class Newsletter(object):
     def init_app(self, app):
         """Configure newsletter Mailchimp client."""
         self.app = app
-        self.dc = app.config.get('MAILCHIMP_API_KEY').split('-')[1]
-        self.root = 'https://%s.api.mailchimp.com/3.0' % self.dc
-        self.auth = HTTPBasicAuth('user', app.config.get('MAILCHIMP_API_KEY'))
-        self.list_id = app.config.get('MAILCHIMP_LIST_ID')
+        if app.config.get('MAILCHIMP_API_KEY'):
+            self.dc = app.config.get('MAILCHIMP_API_KEY').split('-')[1]
+            self.root = 'https://%s.api.mailchimp.com/3.0' % self.dc
+            self.auth = HTTPBasicAuth('user', app.config.get('MAILCHIMP_API_KEY'))
+            self.list_id = app.config.get('MAILCHIMP_LIST_ID')
 
     def is_initialized(self):
         return self.app is not None

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ requirements = [
 
 setup(
     name = 'pybossa',
-    version = '2.9.3',
+    version = '2.9.4',
     packages = find_packages(),
     install_requires = requirements,
     # only needed when installing directly from setup.py (PyPi, eggs?) and pointing to e.g. a git repo.


### PR DESCRIPTION
The job deletes the account, but fails to send the email to the user when the account has been deleted because the MAILCHIMP Key does not exist (which could be true, because the server is not using it). This PR fixes it.