### PR TITLE
Add project_id and category_id to user contribution feed

### DIFF
--- a/pybossa/model/event_listeners.py
+++ b/pybossa/model/event_listeners.py
@@ -142,8 +142,10 @@ def add_user_contributed_to_feed(conn, user_id, project_obj):
                        fullname=r.fullname,
                        info=r.info)
             tmp = User().to_public_json(tmp)
+            tmp['project_id'] = project_obj['id']
             tmp['project_name'] = project_obj['name']
             tmp['project_short_name'] = project_obj['short_name']
+            tmp['category_id'] = project_obj['category_id']
             tmp['action_updated'] = 'UserContribution'
         if tmp:
             update_feed(tmp)


### PR DESCRIPTION
Would it be ok to add these fields to the user contribution activity feed. We want to use this for the front page of each category on LibCrowds. Ee've repurposed each category as its own microsite so each activity feed should only show the projects for that category. This project ID would be useful too!