### PR TITLE
Add category_id to public project attributes

### DIFF
--- a/pybossa/model/project.py
+++ b/pybossa/model/project.py
@@ -128,7 +128,8 @@ class Project(db.Model, DomainObject):
                 'overall_progress', 'short_name', 'created', 'category_id',
                 'long_description', 'last_activity', 'last_activity_raw',
                 'n_task_runs', 'n_results', 'owner', 'updated', 'featured',
-                'owner_id', 'n_completed_tasks', 'n_blogposts', 'owners_ids']
+                'owner_id', 'n_completed_tasks', 'n_blogposts', 'owners_ids',
+                'category_id']
 
     @classmethod
     def public_info_keys(self):


### PR DESCRIPTION
Following https://github.com/Scifabric/pybossa/pull/1848 I just realised that the category_id gets stored as None in the update feed as category_id isn't actually part of the public project attributes - hopefully no other reason not to include it here!