### PR TITLE
Fix 1870

### DIFF
--- a/pybossa/forms/forms.py
+++ b/pybossa/forms/forms.py
@@ -39,6 +39,7 @@ from flask.ext.login import current_user
 import os
 from pybossa.forms.fields.time_field import TimeField
 from validator import TimeFieldsValidator
+from iiif_prezi.loader import ManifestReader
 
 EMAIL_MAX_LENGTH = 254
 USER_NAME_MAX_LENGTH = 35
@@ -296,9 +297,16 @@ class BulkTaskIIIFImportForm(Form):
     manifest_uri = TextField(lazy_gettext('URL'),
                              [validators.Required(message=msg_required),
                              validators.URL(message=msg_url)])
+    version = SelectField(lazy_gettext('Presentation API version'), choices=[
+        (ctx, ctx) for ctx in ManifestReader.contexts
+    ], default='2.1')
 
     def get_import_data(self):
-        return {'type': 'iiif', 'manifest_uri': self.manifest_uri.data}
+        return {
+            'type': 'iiif',
+            'manifest_uri': self.manifest_uri.data,
+            'version': self.version.data
+        }
 
 
 class GenericBulkTaskImportForm(object):

--- a/pybossa/importers/iiif.py
+++ b/pybossa/importers/iiif.py
@@ -79,11 +79,13 @@ class BulkTaskIIIFImporter(BulkTaskImport):
         url = 'http://iiif.io/api/presentation/validator/service/validate'
         payload = dict(format='json', url=manifest_uri)
         response = requests.get(url, params=payload)
-        json_response = json.loads(response.text)
+        default_err = "Oops! That doesn't look like a valid IIIF manifest."
+        try:
+            json_response = json.loads(response.text)
+        except ValueError:
+            raise BulkImportException(default_err)
         valid = (response.status_code == 200 and json_response.get('okay'))
-
         if not valid:
-            default_err = "Oops! That doesn't look like a valid IIIF manifest."
             raise BulkImportException(json_response.get('error', default_err))
 
         manifest = json.loads(json_response['received'])

--- a/pybossa/importers/iiif.py
+++ b/pybossa/importers/iiif.py
@@ -28,9 +28,10 @@ class BulkTaskIIIFImporter(BulkTaskImport):
 
     importer_id = "iiif"
 
-    def __init__(self, manifest_uri):
+    def __init__(self, manifest_uri, version):
         """Init method."""
         self.manifest_uri = manifest_uri
+        self.version = version
 
     def tasks(self):
         """Get tasks."""
@@ -42,7 +43,8 @@ class BulkTaskIIIFImporter(BulkTaskImport):
 
     def _generate_tasks(self):
         """Generate the tasks."""
-        manifest = self._get_validated_manifest(self.manifest_uri)
+        manifest = self._get_validated_manifest(self.manifest_uri,
+                                                self.version)
         task_data = self._get_task_data(manifest)
         return [dict(info=data) for data in task_data]
 
@@ -75,7 +77,7 @@ class BulkTaskIIIFImporter(BulkTaskImport):
         query = '?manifest={}#?cv={}'.format(manifest_uri, canvas_index)
         return base + query
 
-    def _get_validated_manifest(self, manifest_uri, version="2.1"):
+    def _get_validated_manifest(self, manifest_uri, version):
         """Return a validated manifest."""
         r = requests.get(manifest_uri)
         if r.status_code != 200:

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,8 @@ requirements = [
     "pycountry",
     "wtforms-components>=0.10.3, <0.10.4",
     "yacryptopan",
-    "Faker"
+    "Faker",
+    "iiif-prezi>=0.2.9, <1.0.0"
 ]
 
 setup(

--- a/test/test_importers/test_iiif_importer.py
+++ b/test/test_importers/test_iiif_importer.py
@@ -31,7 +31,7 @@ class TestBulkTaskIIIFImport(object):
         self.manifest_uri = 'http://example.org/iiif/book1/manifest'
         self.canvas_id_base = 'http://example.org/iiif/book1/canvas/p{0}'
         self.img_id_base = 'http://example.org/images/book1-page{0}-img{1}'
-        self.importer = BulkTaskIIIFImporter(manifest_uri=self.manifest_uri)
+        self.importer = BulkTaskIIIFImporter(self.manifest_uri, '2.1')
 
     def create_manifest(self, canvases=1, images=1):
         manifest = {
@@ -161,5 +161,5 @@ class TestBulkTaskIIIFImport(object):
         response = FakeResponse(text=json.dumps(manifest), status_code=200,
                                 headers=headers, encoding='utf-8')
         requests.get.return_value = response
-        returned_manifest = self.importer._get_validated_manifest(None)
+        returned_manifest = self.importer._get_validated_manifest(None, '2.1')
         assert_equal(type(returned_manifest), OrderedDict)

--- a/test/test_importers/test_iiif_importer.py
+++ b/test/test_importers/test_iiif_importer.py
@@ -163,3 +163,12 @@ class TestBulkTaskIIIFImport(object):
         requests.get.return_value = response
         returned_manifest = self.importer._get_validated_manifest(None, '2.1')
         assert_equal(type(returned_manifest), OrderedDict)
+
+    def test_exception_when_404_response_for_manifest(self, requests):
+        headers = {'Content-Type': 'application/json'}
+        manifest = self.create_manifest()
+        response = FakeResponse(text=json.dumps(manifest), status_code=404,
+                                headers=headers, encoding='utf-8')
+        requests.get.return_value = response
+        assert_raises(BulkImportException,
+                      self.importer._get_validated_manifest, None, '2.1')

--- a/test/test_importers/test_iiif_importer.py
+++ b/test/test_importers/test_iiif_importer.py
@@ -22,6 +22,7 @@ from nose.tools import *
 from pybossa.importers import BulkImportException
 from pybossa.importers.iiif import BulkTaskIIIFImporter
 from default import FakeResponse, with_context
+from collections import OrderedDict
 
 @patch('pybossa.importers.iiif.requests')
 class TestBulkTaskIIIFImport(object):
@@ -34,9 +35,13 @@ class TestBulkTaskIIIFImport(object):
 
     def create_manifest(self, canvases=1, images=1):
         manifest = {
+            '@context': 'http://iiif.io/api/presentation/2/context.json',
             '@id': self.manifest_uri,
+            '@type': 'sc:Manifest',
+            'label': 'Foo',
             'sequences': [
                 {
+                    '@type': 'sc:Sequence',
                     'canvases': []
                 }
             ]
@@ -44,15 +49,24 @@ class TestBulkTaskIIIFImport(object):
         for i in range(canvases):
             canvas = {
                 '@id': self.canvas_id_base.format(i),
+                '@type': 'sc:Canvas',
+                'label': 'Bar',
+                'height': 100,
+                'width': 100,
                 'images': []
             }
             for j in range(images):
                 image = {
+                    '@type': 'oa:Annotation',
+                    'motivation': 'sc:painting',
                     'resource': {
+                        '@id': 'http://example.org/image{}.jpg'.format(j),
+                        '@type': 'dctypes:Image',
                         'service': {
                             '@id': self.img_id_base.format(i, j)
                         }
-                    }
+                    },
+                    'on': 'http://example.org/{}'.format(i)
                 }
                 canvas['images'].append(image)
             manifest['sequences'][0]['canvases'].append(canvas)
@@ -60,82 +74,61 @@ class TestBulkTaskIIIFImport(object):
 
     def test_task_count_returns_1_for_valid_manifest(self, requests):
         headers = {'Content-Type': 'application/json'}
-        wrapper = {
-            'okay': 1,
-            'received': json.dumps(self.create_manifest())
-        }
-        valid_manifest = FakeResponse(text=json.dumps(wrapper),
-                                      status_code=200, headers=headers,
-                                      encoding='utf-8')
-        requests.get.return_value = valid_manifest
+        manifest = self.create_manifest()
+        response = FakeResponse(text=json.dumps(manifest), status_code=200,
+                                headers=headers, encoding='utf-8')
+        requests.get.return_value = response
         count = self.importer.count_tasks()
         assert_equal(count, 1)
 
     def test_task_count_raises_exception_for_invalid_manifest(self, requests):
         headers = {'Content-Type': 'application/json'}
-        wrapper = {
-            'okay': 0,
-            'received': 'Something else'
+        invalid_manifest = {
+            'foo': 'bar'
         }
-        invalid_manifest = FakeResponse(text=json.dumps(wrapper),
-                                        status_code=200, headers=headers,
-                                        encoding='utf-8')
-        requests.get.return_value = invalid_manifest
-        msg = "Oops! That doesn't look like a valid IIIF manifest."
-
+        response = FakeResponse(text=json.dumps(invalid_manifest),
+                                status_code=200, headers=headers,
+                                encoding='utf-8')
+        requests.get.return_value = response
         assert_raises(BulkImportException, self.importer.count_tasks)
-        try:
-            self.importer.count_tasks()
-        except BulkImportException as e:
-            assert e[0] == msg, e
 
     @with_context
     def test_get_tasks_raises_exception_for_invalid_manifest(self, requests):
         headers = {'Content-Type': 'application/json'}
-        wrapper = {
-            'okay': 0,
-            'received': 'Something else'
+        invalid_manifest = {
+            'foo': 'bar'
         }
-        invalid_manifest = FakeResponse(text=json.dumps(wrapper),
-                                        status_code=200, headers=headers,
-                                        encoding='utf-8')
-        requests.get.return_value = invalid_manifest
-        msg = "Oops! That doesn't look like a valid IIIF manifest."
+        response = FakeResponse(text=json.dumps(invalid_manifest),
+                                status_code=200, headers=headers,
+                                encoding='utf-8')
+        requests.get.return_value = response
+        assert_raises(BulkImportException, self.importer.tasks)
 
+    @with_context
+    def test_task_count_raises_exception_for_non_json_manifest(self, requests):
+        headers = {'Content-Type': 'application/json'}
+        text = 'bad response'
+        response = FakeResponse(text=text, status_code=200)
+        requests.get.return_value = response
         assert_raises(BulkImportException, self.importer.count_tasks)
-        try:
-            self.importer.tasks()
-        except BulkImportException as e:
-            assert e[0] == msg, e
 
     @with_context
     def test_get_tasks_raises_exception_for_non_json_manifest(self, requests):
         headers = {'Content-Type': 'application/json'}
         text = 'bad response'
-        invalid_manifest = FakeResponse(text=text, status_code=200)
-        requests.get.return_value = invalid_manifest
-        msg = "Oops! That doesn't look like a valid IIIF manifest."
-
-        assert_raises(BulkImportException, self.importer.count_tasks)
-        try:
-            self.importer.tasks()
-        except BulkImportException as e:
-            assert e[0] == msg, e
+        response = FakeResponse(text=text, status_code=200)
+        requests.get.return_value = response
+        assert_raises(BulkImportException, self.importer.tasks)
 
     @with_context
     def test_get_tasks_for_valid_manifest(self, requests):
         n_canvases = 3
         n_images = 2
         manifest = self.create_manifest(canvases=n_canvases, images=n_images)
-        wrapper = {
-            'okay': 1,
-            'received': json.dumps(manifest)
-        }
         headers = {'Content-Type': 'application/json'}
-        valid_manifest = FakeResponse(text=json.dumps(wrapper),
-                                      status_code=200, headers=headers,
-                                      encoding='utf-8')
-        requests.get.return_value = valid_manifest
+        response = FakeResponse(text=json.dumps(manifest), status_code=200,
+                                headers=headers, encoding='utf-8')
+        requests.get.return_value = response
         tasks = self.importer.tasks()
 
         # Check task generated for all images of all canvases
@@ -164,13 +157,9 @@ class TestBulkTaskIIIFImport(object):
 
     def test_validated_manifest_returned_as_json(self, requests):
         headers = {'Content-Type': 'application/json'}
-        wrapper = {
-            'okay': 1,
-            'received': json.dumps(self.create_manifest())
-        }
-        valid_manifest = FakeResponse(text=json.dumps(wrapper),
-                                      status_code=200, headers=headers,
-                                      encoding='utf-8')
-        requests.get.return_value = valid_manifest
+        manifest = self.create_manifest()
+        response = FakeResponse(text=json.dumps(manifest), status_code=200,
+                                headers=headers, encoding='utf-8')
+        requests.get.return_value = response
         returned_manifest = self.importer._get_validated_manifest(None)
-        assert_equal(type(returned_manifest), dict)
+        assert_equal(type(returned_manifest), OrderedDict)

--- a/test/test_importers/test_iiif_importer.py
+++ b/test/test_importers/test_iiif_importer.py
@@ -109,6 +109,20 @@ class TestBulkTaskIIIFImport(object):
             assert e[0] == msg, e
 
     @with_context
+    def test_get_tasks_raises_exception_for_non_json_manifest(self, requests):
+        headers = {'Content-Type': 'application/json'}
+        text = 'bad response'
+        invalid_manifest = FakeResponse(text=text, status_code=200)
+        requests.get.return_value = invalid_manifest
+        msg = "Oops! That doesn't look like a valid IIIF manifest."
+
+        assert_raises(BulkImportException, self.importer.count_tasks)
+        try:
+            self.importer.tasks()
+        except BulkImportException as e:
+            assert e[0] == msg, e
+
+    @with_context
     def test_get_tasks_for_valid_manifest(self, requests):
         n_canvases = 3
         n_images = 2


### PR DESCRIPTION
Close #1870 

Basically removes the reliance on the external IIIF manifest validation server. Also adds in the option to choose the IIIF presentation API version to validate the manifest against.