### PR TITLE
Allow helpingmaterial to get JSON when sending files.

### DIFF
--- a/pybossa/api/api_base.py
+++ b/pybossa/api/api_base.py
@@ -314,6 +314,7 @@ class APIBase(MethodView):
             json_response = json.dumps(inst.dictize())
             return Response(json_response, mimetype='application/json')
         except Exception as e:
+            raise
             content_type = request.headers.get('Content-Type')
             if (cls_name == 'TaskRun'
                     and 'multipart/form-data' in content_type
@@ -486,7 +487,6 @@ class APIBase(MethodView):
             tmp = dict()
             for key in request.form.keys():
                 tmp[key] = request.form[key]
-
             if isinstance(self, announcement.Announcement):
                 # don't check project id for announcements
                 ensure_authorized_to('create', self)
@@ -520,6 +520,8 @@ class APIBase(MethodView):
             tmp['media_url'] = file_url
             if tmp.get('info') is None:
                 tmp['info'] = dict()
+            elif type(tmp['info']) is unicode:
+                tmp['info'] = json.loads(tmp['info'])
             tmp['info']['container'] = container
             tmp['info']['file_name'] = _file.filename
             return tmp

--- a/pybossa/api/api_base.py
+++ b/pybossa/api/api_base.py
@@ -314,7 +314,6 @@ class APIBase(MethodView):
             json_response = json.dumps(inst.dictize())
             return Response(json_response, mimetype='application/json')
         except Exception as e:
-            raise
             content_type = request.headers.get('Content-Type')
             if (cls_name == 'TaskRun'
                     and 'multipart/form-data' in content_type

--- a/test/test_api/test_api_helpingmaterial.py
+++ b/test/test_api/test_api_helpingmaterial.py
@@ -325,7 +325,8 @@ class TestHelpingMaterialAPI(TestAPI):
         img = (io.BytesIO(b'test'), 'test_file.jpg')
 
         payload = dict(project_id=project.id,
-                       file=img)
+                       file=img,
+                       info=json.dumps(dict(foo=1)))
 
         url = '/api/helpingmaterial?api_key=%s' % project.owner.api_key
         res = self.app.post(url, data=payload,
@@ -335,6 +336,7 @@ class TestHelpingMaterialAPI(TestAPI):
         container = "user_%s" % owner.id
         assert data['info']['container'] == container, data
         assert data['info']['file_name'] == 'test_file.jpg', data
+        assert data['info']['foo'] == 1, data
         assert 'test_file.jpg' in data['media_url'], data
 
         # As owner wrong 404 project_id


### PR DESCRIPTION
Right now when you send an API POST request to helpingmaterial with a file and some JSON data, it fails. This PR should fix it.