### PR TITLE
Fix so that redis is not called when REDIS is disabled.

### DIFF
--- a/pybossa/cache/__init__.py
+++ b/pybossa/cache/__init__.py
@@ -88,7 +88,6 @@ def cache(key_prefix, timeout=300):
                 sentinel.master.setex(key, timeout, pickle.dumps(output))
                 return output
             output = f(*args, **kwargs)
-            sentinel.master.setex(key, timeout, pickle.dumps(output))
             return output
         return wrapper
     return decorator
@@ -117,7 +116,6 @@ def memoize(timeout=300):
                 sentinel.master.setex(key, timeout, pickle.dumps(output))
                 return output
             output = f(*args, **kwargs)
-            sentinel.master.setex(key, timeout, pickle.dumps(output))
             return output
         return wrapper
     return decorator


### PR DESCRIPTION
Both the wrappers `cache` and `memoize` called `sentinel.master.setex`
even when `PYBOSSA_REDIS_CACHE_DISABLED` is set.