### PR TITLE
Enable usage of PyBossa in non-subdomain setup.

### DIFF
--- a/settings_local.py.tmpl
+++ b/settings_local.py.tmpl
@@ -53,6 +53,9 @@ CONTACT_TWITTER = 'PyBossa'
 ## Default number of projects per page
 ## APPS_PER_PAGE = 20
 
+## Set STATIC_URL_PATH if PyBossa is used in non-subdomain setup.
+# STATIC_URL_PATH = '/ws/tools/crowd-tasking/static'
+
 ## External Auth providers
 # TWITTER_CONSUMER_KEY=''
 # TWITTER_CONSUMER_SECRET=''
@@ -285,7 +288,7 @@ CRYPTOPAN_KEY = '32-char-str-for-AES-key-and-pad.'
 # TTL for ZIP files of personal data
 TTL_ZIP_SEC_FILES = 3
 
-# Instruct PYBOSSA to generate HTTP or HTTPS 
+# Instruct PYBOSSA to generate HTTP or HTTPS
 PREFERRED_URL_SCHEME='https'
 
 # Instruct PYBOSSA to generate absolute paths or not for avatars


### PR DESCRIPTION
- Added STATIC_URL_PATH to settings.
- If STATIC_URL_PATH is set, then update rules to serve static folder.