### PR TITLE
fix(redis): cache was bad handled.

### DIFF
--- a/pybossa/core.py
+++ b/pybossa/core.py
@@ -60,8 +60,7 @@ def create_app(run_as_server=True):
     if app.config.get('SENTRY_DSN'):  # pragma: no cover
         Sentry(app)
     if run_as_server:  # pragma: no cover
-        if util.redis_cache_is_enabled():
-            setup_scheduled_jobs(app)
+        setup_scheduled_jobs(app)
     setup_blueprints(app)
     setup_hooks(app)
     setup_error_handlers(app)
@@ -536,9 +535,7 @@ def setup_hooks(app):
     @app.context_processor
     def _global_template_context():
         notify_admin = False
-        if (util.redis_cache_is_enabled()
-            and current_user
-            and current_user.is_authenticated()
+        if (current_user and current_user.is_authenticated()
                 and current_user.admin):
             key = NEWS_FEED_KEY + str(current_user.id)
             if sentinel.slave.get(key):

--- a/pybossa/core.py
+++ b/pybossa/core.py
@@ -97,8 +97,10 @@ def configure_app(app):
     else:
         config_path = os.path.abspath(os.environ.get('PYBOSSA_SETTINGS'))
 
-    config_upref_mdata = os.path.join(os.path.dirname(config_path), 'settings_upref_mdata.py')
-    app.config.upref_mdata = True if os.path.exists(config_upref_mdata) else False
+    config_upref_mdata = os.path.join(
+        os.path.dirname(config_path), 'settings_upref_mdata.py')
+    app.config.upref_mdata = True if os.path.exists(
+        config_upref_mdata) else False
 
     # Override DB in case of testing
     if app.config.get('SQLALCHEMY_DATABASE_TEST_URI'):
@@ -118,6 +120,7 @@ def setup_json_serializer(app):
 
 def setup_cors(app):
     cors.init_app(app, resources=app.config.get('CORS_RESOURCES'))
+
 
 def setup_sse(app):
     if app.config['SSE']:
@@ -249,7 +252,7 @@ def setup_logging(app):
         file_handler.setFormatter(Formatter(
             '%(name)s:%(levelname)s:[%(asctime)s] %(message)s '
             '[in %(pathname)s:%(lineno)d]'
-            ))
+        ))
         file_handler.setLevel(log_level)
         app.logger.addHandler(file_handler)
         logger = logging.getLogger('pybossa')
@@ -280,7 +283,7 @@ def setup_babel(app):
         else:
             lang = request.cookies.get('language')
         if (lang is None or lang == '' or
-            lang.lower() not in locales):
+                lang.lower() not in locales):
             lang = request.accept_languages.best_match(locales)
         if (lang is None or lang == '' or
                 lang.lower() not in locales):
@@ -435,6 +438,7 @@ def setup_twitter_importer(app):
         log_message = 'Twitter importer not available: %s' % str(inst)
         app.logger.info(log_message)
 
+
 def setup_youtube_importer(app):
     try:  # pragma: no cover
         if app.config['YOUTUBE_API_SERVER_KEY']:
@@ -449,6 +453,7 @@ def setup_youtube_importer(app):
         print "Youtube importer not available"
         log_message = 'Youtube importer not available: %s' % str(inst)
         app.logger.info(log_message)
+
 
 def url_for_other_page(page):
     """Setup url for other pages."""
@@ -528,14 +533,13 @@ def setup_hooks(app):
             except TypeError:
                 abort(400)
 
-
     @app.context_processor
     def _global_template_context():
         notify_admin = False
         if (util.redis_cache_is_enabled()
             and current_user
             and current_user.is_authenticated()
-            and current_user.admin):
+                and current_user.admin):
             key = NEWS_FEED_KEY + str(current_user.id)
             if sentinel.slave.get(key):
                 notify_admin = True
@@ -615,7 +619,7 @@ def setup_jinja2_filters(app):
         return humanize.intword(obj)
 
     @app.template_filter('disqus_sso')
-    def _disqus_sso(obj): # pragma: no cover
+    def _disqus_sso(obj):  # pragma: no cover
         return get_disqus_sso(obj)
 
 
@@ -716,18 +720,20 @@ def setup_ldap(app):
     if app.config.get('LDAP_HOST'):
         ldap.init_app(app)
 
+
 def setup_profiler(app):
     if app.config.get('FLASK_PROFILER'):
         flask_profiler.init_app(app)
+
 
 def setup_upref_mdata(app):
     """Setup user preference and metadata choices for user accounts"""
     global upref_mdata_choices
     upref_mdata_choices = dict(languages=[], locations=[],
-                                timezones=[], user_types=[])
+                               timezones=[], user_types=[])
     if app.config.upref_mdata:
         from settings_upref_mdata import (upref_languages, upref_locations,
-                mdata_timezones, mdata_user_types)
+                                          mdata_timezones, mdata_user_types)
         upref_mdata_choices['languages'] = upref_languages()
         upref_mdata_choices['locations'] = upref_locations()
         upref_mdata_choices['timezones'] = mdata_timezones()

--- a/pybossa/feed.py
+++ b/pybossa/feed.py
@@ -23,29 +23,26 @@ try:
 except ImportError:  # pragma: no cover
     import pickle
 
-from pybossa import util
-
 
 FEED_KEY = 'pybossa_feed'
 
 
 def update_feed(obj):
     """Add domain object to update feed in Redis."""
-    if util.redis_cache_is_enabled():
-        pipeline = sentinel.master.pipeline()
-        serialized_object = pickle.dumps(obj)
-        pipeline.zadd(FEED_KEY, time(), serialized_object)
-        pipeline.execute()
+    pipeline = sentinel.master.pipeline()
+    serialized_object = pickle.dumps(obj)
+    pipeline.zadd(FEED_KEY, time(), serialized_object)
+    pipeline.execute()
+
 
 def get_update_feed():
     """Return update feed list."""
     feed = []
-    if util.redis_cache_is_enabled():
-        data = sentinel.slave.zrevrange(FEED_KEY, 0, 99, withscores=True)
-        for u in data:
-            tmp = pickle.loads(u[0])
-            tmp['updated'] = u[1]
-            if tmp.get('info') and type(tmp.get('info')) == unicode:
-                tmp['info'] = json.loads(tmp['info'])
-            feed.append(tmp)
+    data = sentinel.slave.zrevrange(FEED_KEY, 0, 99, withscores=True)
+    for u in data:
+        tmp = pickle.loads(u[0])
+        tmp['updated'] = u[1]
+        if tmp.get('info') and type(tmp.get('info')) == unicode:
+            tmp['info'] = json.loads(tmp['info'])
+        feed.append(tmp)
     return feed

--- a/pybossa/util.py
+++ b/pybossa/util.py
@@ -45,7 +45,7 @@ import pycountry
 
 
 def redis_cache_is_enabled():
-    return os.environ.get('PYBOSSA_REDIS_CACHE_DISABLED', '0') != '1'
+    return os.environ.get('PYBOSSA_REDIS_CACHE_DISABLED') is None
 
 
 def last_flashed_message():
@@ -85,7 +85,7 @@ def handle_content_type(data):
     """Return HTML or JSON based on request type."""
     from pybossa.model.project import Project
     if (request.headers.get('Content-Type') == 'application/json' or
-        request.args.get('response_format') == 'json'):
+            request.args.get('response_format') == 'json'):
         message_and_status = last_flashed_message()
         if message_and_status:
             data['flash'] = message_and_status[1]
@@ -96,7 +96,8 @@ def handle_content_type(data):
             if isinstance(data[item], Pagination):
                 data[item] = data[item].to_json()
             if (item == 'announcements'):
-                data[item] = [announcement.to_public_json() for announcement in data[item]]
+                data[item] = [announcement.to_public_json()
+                              for announcement in data[item]]
             if (item == 'blogposts'):
                 data[item] = [blog.to_public_json() for blog in data[item]]
             if (item == 'categories'):
@@ -139,7 +140,7 @@ def redirect_content_type(url, status=None):
     if status is not None:
         data['status'] = status
     if (request.headers.get('Content-Type') == 'application/json' or
-        request.args.get('response_format') == 'json'):
+            request.args.get('response_format') == 'json'):
         return handle_content_type(data)
     else:
         return redirect(url)
@@ -464,7 +465,8 @@ def _last_activity_points(project):
     updated_datetime = updated_datetime.split('.')[0]
     last_activity_datetime = last_activity_datetime.split('.')[0]
     updated = datetime.strptime(updated_datetime, '%Y-%m-%dT%H:%M:%S')
-    last_activity = datetime.strptime(last_activity_datetime, '%Y-%m-%dT%H:%M:%S')
+    last_activity = datetime.strptime(
+        last_activity_datetime, '%Y-%m-%dT%H:%M:%S')
     most_recent = max(updated, last_activity)
 
     days_since_modified = (datetime.utcnow() - most_recent).days
@@ -620,8 +622,8 @@ def check_password_strength(
     pwd_len = len(password)
     if pwd_len < min_len or pwd_len > max_len:
         message = lazy_gettext(
-                    u'Password must be between {0} and {1} characters'
-                    .format(min_len, max_len))
+            u'Password must be between {0} and {1} characters'
+            .format(min_len, max_len))
         return False, message
 
     valid = all(re.search(ch, password) for ch in required_chars)

--- a/test/test_cache/test_site_stats.py
+++ b/test/test_cache/test_site_stats.py
@@ -156,10 +156,12 @@ class TestSiteStatsCache(Test):
     def test_get_top5_projects_24_hours_considers_last_24_hours_contributions_only(self):
         recently_contributed_project = ProjectFactory.create()
         long_ago_contributed_project = ProjectFactory.create()
-        two_days_ago = (datetime.datetime.utcnow() -  datetime.timedelta(2)).isoformat()
+        two_days_ago = (datetime.datetime.utcnow() -
+                        datetime.timedelta(2)).isoformat()
 
         TaskRunFactory.create(project=recently_contributed_project)
-        TaskRunFactory.create(project=long_ago_contributed_project, finish_time=two_days_ago)
+        TaskRunFactory.create(
+            project=long_ago_contributed_project, finish_time=two_days_ago)
 
         top5 = stats.get_top5_projects_24_hours()
         top5_ids = [top['id'] for top in top5]
@@ -203,10 +205,12 @@ class TestSiteStatsCache(Test):
     def test_get_top5_users_24_hours_considers_last_24_hours_contributions_only(self):
         recently_contributing_user = UserFactory.create()
         long_ago_contributing_user = UserFactory.create()
-        two_days_ago = (datetime.datetime.utcnow() -  datetime.timedelta(2)).isoformat()
+        two_days_ago = (datetime.datetime.utcnow() -
+                        datetime.timedelta(2)).isoformat()
 
         TaskRunFactory.create(user=recently_contributing_user)
-        TaskRunFactory.create(user=long_ago_contributing_user, finish_time=two_days_ago)
+        TaskRunFactory.create(
+            user=long_ago_contributing_user, finish_time=two_days_ago)
 
         top5 = stats.get_top5_users_24_hours()
         top5_ids = [top['id'] for top in top5]


### PR DESCRIPTION
Revert back changes introduced by @kod-kristoff .

The changes caused several problems. For example, all background jobs were disabled, and those jobs are required to run a PYBOSSA server.

Also, the cache is different from why PYBOSSA uses Redis/Sentinel. Redis is used for caching some queries, but also, for handling information via the API (like stats).

For this reason, these commits revert back all the changes and restore the default behavior. 