### PR TITLE
fix: Ensure that retrieve_timestamp returns a string and not bytes

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -153,6 +153,28 @@ def fix_task_date():
             db.engine.execute(query, created=fixed_created, id=task.id)
 
 
+def fix_task_run_created_date():
+    """Fix Date format in Task."""
+    import re
+    from datetime import datetime
+    with app.app_context():
+        query = text(
+            '''SELECT id, created FROM task_run WHERE created LIKE ('\x%')''')
+        results = db.engine.execute(query)
+        task_runs = results.fetchall()
+        for task_run in task_runs:
+            # It's a hex string
+            try:
+                hex_check = task_run.created.replace('\\x', '')
+                int(hex_check, 16)
+                fixed_created = bytes.fromhex(hex_check).decode()
+            except ValueError:
+                fixed_created = task_run.created
+            print(fixed_created)
+            query = text('''UPDATE task_run SET created=:created WHERE id=:id''')
+            db.engine.execute(query, created=fixed_created, id=task_run.id)
+
+
 def delete_hard_bounces():
     '''Delete fake accounts from hard bounces.'''
     del_users = 0

--- a/pybossa/contributions_guard.py
+++ b/pybossa/contributions_guard.py
@@ -38,7 +38,8 @@ class ContributionsGuard(object):
 
     def retrieve_timestamp(self, task, user):
         key = self._create_key(task, user)
-        return self.conn.get(key)
+        timestamp = self.conn.get(key)
+        return timestamp and timestamp.decode()
 
     def _create_key(self, task, user):
         user_id = user['user_id'] or user['user_ip']

--- a/test/test_contributions_guard.py
+++ b/test/test_contributions_guard.py
@@ -83,8 +83,8 @@ class TestContributionsGuard(object):
         assert self.guard.retrieve_timestamp(self.task, self.auth_user) is None
 
     @patch('pybossa.contributions_guard.make_timestamp')
-    def test_retrieve_timestamp_returs_the_timestamp_for_stamped_task(self, make_timestamp):
-        make_timestamp.return_value = b'now'
+    def test_retrieve_timestamp_returns_the_timestamp_for_stamped_task(self, make_timestamp):
+        make_timestamp.return_value = 'now'
         self.guard.stamp(self.task, self.auth_user)
 
-        assert self.guard.retrieve_timestamp(self.task, self.auth_user) == b'now'
+        assert self.guard.retrieve_timestamp(self.task, self.auth_user) == 'now'


### PR DESCRIPTION
Fixes: [#1969](https://github.com/Scifabric/pybossa/issues/1969)