### PR TITLE
fix(gdpr): delete inactive accounts.

### DIFF
--- a/alembic/versions/a791f9de9ac3_add_new_notify_column_to_user.py
+++ b/alembic/versions/a791f9de9ac3_add_new_notify_column_to_user.py
@@ -1,0 +1,22 @@
+"""Add new notify column to user
+
+Revision ID: a791f9de9ac3
+Revises: 66ecf0b2aed5
+Create Date: 2020-05-23 16:01:27.795514
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'a791f9de9ac3'
+down_revision = '66ecf0b2aed5'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('user', sa.Column('notified_at', sa.Date, default=None))
+
+
+def downgrade():
+    op.drop_column('user', 'notified_at')

--- a/pybossa/jobs.py
+++ b/pybossa/jobs.py
@@ -501,8 +501,10 @@ def warn_old_project_owners():
     return True
 
 
-def send_mail(message_dict):
+def send_mail(message_dict, user_id=None):
     """Send email."""
+    from pybossa.core import db
+    from pybossa.model.user import User
     message = Message(**message_dict)
     spam = False
     for r in message_dict['recipients']:
@@ -512,6 +514,11 @@ def send_mail(message_dict):
             break
     if not spam:
         mail.send(message)
+        if user_id:
+            user = User.query.get(user_id)
+            user.notified_at = datetime.now()
+            db.session.add(user)
+            db.session.commit()
 
 
 def import_tasks(project_id, from_auto=False, **form_data):
@@ -934,7 +941,7 @@ def get_notify_inactive_accounts(queue='monthly'):
                              html=html)
 
             job = dict(name=send_mail,
-                       args=[mail_dict],
+                       args=[mail_dict, user.id],
                        kwargs={},
                        timeout=timeout,
                        queue=queue)
@@ -947,19 +954,9 @@ def get_delete_inactive_accounts(queue='bimonthly'):
     from pybossa.model.user import User
     from pybossa.core import db
     timeout = current_app.config.get('TIMEOUT')
-    time = current_app.config.get('USER_INACTIVE_DELETE')
+    time = current_app.config.get('USER_DELETE_AFTER_NOTIFICATION', '1 month')
 
-    sql = text('''SELECT "user".id from "user", task_run
-               WHERE "user".id = task_run.user_id AND "user".id NOT IN
-               (SELECT user_id FROM task_run
-               WHERE user_id IS NOT NULL
-               AND to_date(task_run.finish_time, 'YYYY-MM-DD\THH24:MI:SS.US')
-               >= NOW() - '{} month'::INTERVAL
-               GROUP BY user_id
-               ORDER BY user_id) AND
-               "user".admin=false
-               GROUP BY "user".id ORDER BY "user".id
-               ;'''.format(time))
+    sql = f"select * from \"user\" where notified_at < NOW() - INTERVAL '{time}';"
 
     results = db.slave_session.execute(sql)
 

--- a/pybossa/model/event_listeners.py
+++ b/pybossa/model/event_listeners.py
@@ -252,6 +252,12 @@ def on_taskrun_submit(mapper, conn, target):
         project_private['webhook'] = _webhook
         push_webhook(project_private, target.task_id, result_id)
 
+    # Every time a registered user contributes a taskrun its notified_at column is reset
+    # so the job for deleting inactive accounts, is not triggered
+    if target.user_id:
+        sql = f"update \"user\" set notified_at=null where \"user\".id={target.user_id};"
+        conn.execute(sql)
+
 
 @event.listens_for(Blogpost, 'after_insert')
 @event.listens_for(Blogpost, 'after_update')

--- a/pybossa/model/user.py
+++ b/pybossa/model/user.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with PYBOSSA.  If not, see <http://www.gnu.org/licenses/>.
 
-from sqlalchemy import Integer, Boolean, Unicode, Text, String, BigInteger
+from sqlalchemy import Integer, Boolean, Unicode, Text, String, BigInteger, Date
 from sqlalchemy.schema import Column
 from sqlalchemy.orm import relationship
 from sqlalchemy.dialects.postgresql import JSONB
@@ -66,6 +66,7 @@ class User(db.Model, DomainObject, UserMixin):
     consent = Column(Boolean, default=False)
     info = Column(MutableDict.as_mutable(JSONB), default=dict())
     user_pref = Column(JSONB)
+    notified_at = Column(Date, default=None)
 
     ## Relationships
     task_runs = relationship(TaskRun, backref='user')

--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,8 @@ requirements = [
     "wrapt==1.10.11",
     "WTForms>=1.0.5",
     "WTForms-Components>=0.10.3",
-    "yacryptopan==1.0.0"
+    "yacryptopan==1.0.0",
+    "email_validator==1.1.1"
 ]
 
 setup(


### PR DESCRIPTION
This new PR fixes a problem with the deletion of accounts.

First it simplifies the process:

 * We check for users that have sent a taskrun more than X months ago.
 * For those users, we send an email saying that if in the coming month
 they do not contribute again, their accounts will be deleted.
 * We then run another job that will check for users that have been
 notified one month ago or more, if they exist, those accounts are
 deleted.
 * As soon as an account submits a taskrun the notified_at value changes
 to null, disabling the deletion.