### PR TITLE
Fixed unicode error on cli.py

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -159,7 +159,7 @@ def fix_task_run_created_date():
     from datetime import datetime
     with app.app_context():
         query = text(
-            '''SELECT id, created FROM task_run WHERE created LIKE ('\x%')''')
+            '''SELECT id, created FROM task_run WHERE created LIKE ('\\x%')''')
         results = db.engine.execute(query)
         task_runs = results.fetchall()
         for task_run in task_runs:


### PR DESCRIPTION
Found this error trying to run `python cli.py db_create` with Python 3.8.

File "cli.py", line 162
    '''SELECT id, created FROM task_run WHERE created LIKE ('\x%')''')
    ^
SyntaxError: (unicode error) 'unicodeescape' codec can't decode bytes in position 54-55: truncated \xXX escape

And I am sending the easy solution. Can you check that it works with other Python versions?