### PR TITLE
Fix unicode problem with db

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -159,7 +159,7 @@ def fix_task_run_created_date():
     from datetime import datetime
     with app.app_context():
         query = text(
-            '''SELECT id, created FROM task_run WHERE created LIKE ('\x%')''')
+            '''SELECT id, created FROM task_run WHERE created LIKE ('\\x%')''')
         results = db.engine.execute(query)
         task_runs = results.fetchall()
         for task_run in task_runs:


### PR DESCRIPTION
This fix is described here https://stackoverflow.com/questions/60923607/multiple-issues-trying-to-install-pybossa

For some reason the problem with '\x' appears with AWS RDS while no problem with GCP CloudSQL