### PR TITLE
feat: support for no sentinel setup

### DIFF
--- a/pybossa/sentinel/__init__.py
+++ b/pybossa/sentinel/__init__.py
@@ -31,10 +31,17 @@ class Sentinel(object):
     def init_app(self, app):
         socket_timeout = app.config.get('REDIS_SOCKET_TIMEOUT', None)
         retry_on_timeout = app.config.get('REDIS_RETRY_ON_TIMEOUT', True)
-        self.connection = sentinel.Sentinel(app.config['REDIS_SENTINEL'],
-                                            socket_timeout=socket_timeout,
-                                            retry_on_timeout=retry_on_timeout)
-        redis_db = app.config.get('REDIS_DB') or 0
-        redis_master = app.config.get('REDIS_MASTER') or 'mymaster'
-        self.master = self.connection.master_for(redis_master, db=redis_db)
-        self.slave = self.connection.slave_for(redis_master, db=redis_db)
+        redis_db = app.config.get('REDIS_DB', 0)
+        redis_master = app.config.get('REDIS_MASTER', 'mymaster')
+        if app.config.get('REDIS_SENTINEL'):
+            self.connection = sentinel.Sentinel(app.config['REDIS_SENTINEL'],
+                                                socket_timeout=socket_timeout,
+                                                retry_on_timeout=retry_on_timeout)
+            self.master = self.connection.master_for(redis_master, db=redis_db)
+            self.slave = self.connection.slave_for(redis_master, db=redis_db)
+        else:
+            self.connection = None
+            self.master = StrictRedis(host=app.config.get('REDIS_HOST', 'localhost'),
+                                      port=app.config.get('REDIS_PORT', 6379),
+                                      db=redis_db)
+            self.slave = self.master

--- a/pybossa/sentinel/__init__.py
+++ b/pybossa/sentinel/__init__.py
@@ -43,5 +43,6 @@ class Sentinel(object):
             self.connection = None
             self.master = StrictRedis(host=app.config.get('REDIS_HOST', 'localhost'),
                                       port=app.config.get('REDIS_PORT', 6379),
-                                      db=redis_db)
+                                      db=redis_db,
+                                      password=app.config.get('REDIS_PASSWORD'))
             self.slave = self.master


### PR DESCRIPTION
In case of GCP or AWS managed redis services there will be no sentinel (HA is handled by GCP/AWS). So, need a way to setup pybossa to use redis without sentinel.

With this fix you can set REDIS_SENTINEL setting from settings_local.py to None and set REDIS_HOST and REDIS_PORT instead. In this case pybossa will use redis directly.

In case of REDIS_SENTINEL provided, sentinel will be used.