### PR TITLE
fix: rq_dashboard redis problem

### DIFF
--- a/pybossa/core.py
+++ b/pybossa/core.py
@@ -326,7 +326,7 @@ def setup_blueprints(app):
 
     # from rq_dashboard import RQDashboard
     import rq_dashboard
-    app.config.from_object(rq_dashboard.default_settings)
+    #app.config.from_object(rq_dashboard.default_settings)
     rq_dashboard.blueprint.before_request(is_admin)
     app.register_blueprint(rq_dashboard.blueprint, url_prefix="/admin/rq",
                            redis_conn=sentinel.master)


### PR DESCRIPTION
In core.py:329 it overrides app config with default values from rq_dashboard. As result it is not possible to use external redis because default value for REDIS_HOST is localhost, i.e. rq_dashboard is always works with localhost.

It will be much better to remove this line and just use settings from app config - this way you will be able to configure app and rq_dashboard.