### PR TITLE
change user locale from home page

### DIFF
--- a/pybossa/forms/forms.py
+++ b/pybossa/forms/forms.py
@@ -408,6 +408,20 @@ class UpdateProfileForm(Form):
         self.locale.choices = choices
 
 
+class UpdateLocaleForm(Form):
+
+    """Form Class for updating PYBOSSA's user Locale."""
+
+    locale = SelectField(lazy_gettext('Language'))
+
+    def set_locales(self, locales):
+        """Fill the locale.choices."""
+        choices = []
+        for locale in locales:
+            choices.append(locale)
+        self.locale.choices = choices
+
+
 class ChangePasswordForm(Form):
 
     """Form for changing user's password."""

--- a/pybossa/forms/home_view_forms.py
+++ b/pybossa/forms/home_view_forms.py
@@ -1,0 +1,22 @@
+# -*- coding: utf8 -*-
+# This file is part of PYBOSSA.
+#
+# Copyright (C) 2015 Scifabric LTD.
+#
+# PYBOSSA is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PYBOSSA is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with PYBOSSA.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from .forms import (
+    UpdateLocaleForm,
+    )

--- a/pybossa/view/home.py
+++ b/pybossa/view/home.py
@@ -26,7 +26,7 @@ from pybossa.cache import users as cached_users
 from pybossa.cache import categories as cached_cat
 from pybossa.util import rank, handle_content_type
 from jinja2.exceptions import TemplateNotFound
-
+from pybossa.forms.home_view_forms import UpdateLocaleForm
 
 blueprint = Blueprint('home', __name__)
 
@@ -43,6 +43,14 @@ def home():
         data = dict(featured=rank(tmp_projects))
     else:
         data = dict(featured=[])
+
+    # Allow user to change locale on welcome page
+    if current_user.is_authenticated:
+        # Change locale
+        locale_form = UpdateLocaleForm(obj=current_user)
+        locale_form.set_locales(current_app.config['LOCALES'])
+        data['locale_form'] = locale_form
+
     response = dict(template='/home/index.html', **data)
     return handle_content_type(response)
 


### PR DESCRIPTION
Pybossa users are continuously asking for an quicker way to change his/her locale, other than via the settings page.
This is a first attempt to ease a locale changer on home page (navbar would be even better).  This needs to add a form in template/home/index.html like below.
Please jump in the discussion.


```
{% from "_formhelpers.html" import render_field, render_form %}
...
{% block content %}
<section class="home featured">

    {% if current_user.is_authenticated %}
    <div class="container text-center firstfold">
        <div class="row justified-content-end">
            <div class="col-md-2 col-md-offset-10">
                <form method="POST" action="{{ url_for('account.update_profile', name=current_user.name) }}" role="form" class="{{ class_ }}">
                    {{ locale_form.hidden_tag() if locale_form.hidden_tag }}
                    {% for field in locale_form %}
                        <div class="form-group {% if field.errors %}has-error{% endif %}">
                            {{ field(class_='form-control') }}
                        </div>
                    {% endfor %}
                    <button type="submit" name="btn" value="Profile" class="btn btn-primary">{{ _('Save the changes') }} </button>
                </form>
            </div>
        </div>
    </div>
    {% endif %}
...
```