### PR TITLE
chore: pyparsing 2.4.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ requirements = [
     "PyLD==1.0.4",
     "pyldap==3.0.0.post1",
     "pyOpenSSL==18.0.0",
-    "pyparsing==2.3.0",
+    "pyparsing==2.4.2",
     "python-dateutil==2.7.5",
     "python-editor==1.0.3",
     "python-keystoneclient==3.18.0",


### PR DESCRIPTION
Updates pyparsing from 2.3.0 to 2.4.2. I'm brand new to pybossa, but updating to 2.4.2 got me through the setup, and it will fix https://github.com/Scifabric/pybossa/issues/2035.

Let me know if changes are needed. 

Thank you! pybossa may be exactly what I need for a crowdsourced food inventory thing I want to build.